### PR TITLE
feat(development): add example stacks for all Graviton CDK base types

### DIFF
--- a/development/01-tenant/Pulumi.dev.yaml
+++ b/development/01-tenant/Pulumi.dev.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=.stack_schema.json
+config:
+  azuread:tenantId: "00000000-0000-0000-0000-000000000000"
+  workload_name: tenant
+  env: graviton-dev
+
+  # Pulumi ESC environment configuration
+  esc:
+    env_name: graviton-dev
+
+  # Customer information
+  customer:
+    name: Graviton Example
+    active: true
+
+  # Global settings inherited by all downstream environments
+  globals:
+    location: northeurope
+    ip_allow_list:
+      - 203.0.113.0/24 # RFC 5737 documentation range — replace with your office IP
+    tags:
+      Env: dev
+      WorkloadName: graviton-example
+      ProvisionType: IaC
+      Owner: admin@example.com

--- a/development/01-tenant/Pulumi.yaml
+++ b/development/01-tenant/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: tenant
+description: Azure Tenant configuration — global settings, ESC environment, tagging rules
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/01-tenant/__main__.py
+++ b/development/01-tenant/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Azure Tenant configuration"""
+
+import os
+
+from orbitcloud_graviton.azure_tenant import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/02-environment/Pulumi.dev.yaml
+++ b/development/02-environment/Pulumi.dev.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=.stack_schema.json
+config:
+  azure-native:location: northeurope
+  azure-native:subscriptionId: "11111111-1111-1111-1111-111111111111"
+  azure-native:tenantId: "00000000-0000-0000-0000-000000000000"
+  azuread:tenantId: "00000000-0000-0000-0000-000000000000"
+  workload_name: gvtn
+  env: dev
+
+  # ESC environment name (defaults to env if not set)
+  esc_env_name: graviton-dev
+
+  # Import the tenant-level ESC environment
+  imports:
+    - graviton-dev

--- a/development/02-environment/Pulumi.yaml
+++ b/development/02-environment/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: environments
+description: Azure Environment — Pulumi ESC OIDC credentials and subscription config
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/02-environment/__main__.py
+++ b/development/02-environment/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Azure Environment (Pulumi ESC OIDC)"""
+
+import os
+
+from orbitcloud_graviton.azure_environment import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/03-landing-zone/Pulumi.dev.yaml
+++ b/development/03-landing-zone/Pulumi.dev.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: lz
+
+  # Key Vault with public access for development
+  keyvault:
+    public_network_access: Enabled
+    allowed_public_networks:
+      - 203.0.113.0/24 # RFC 5737 — replace with your office IP range
+
+  # Container Registry
+  container_registry:
+    public_network_access: Enabled
+    admin_user_enabled: true
+    retention_policy_days: 7
+
+  # DNS Zone — register a subdomain for this environment
+  dns_zone:
+    name: example.graviton.dev
+
+  # Request a wildcard ACME/Let's Encrypt certificate for the DNS zone
+  acme_ssl: true

--- a/development/03-landing-zone/Pulumi.yaml
+++ b/development/03-landing-zone/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: landing_zone
+description: Landing Zone — Log Analytics, Key Vault, Container Registry, DNS
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/03-landing-zone/__main__.py
+++ b/development/03-landing-zone/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Landing Zone — Log Analytics, Key Vault, Container Registry"""
+
+import os
+
+from orbitcloud_graviton.landing_zone import deploy_landing_zone
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy_landing_zone()

--- a/development/04-networking/Pulumi.dev.yaml
+++ b/development/04-networking/Pulumi.dev.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: base
+
+  vnet:
+    address_space:
+      - 10.200.0.0/16
+
+    subnets:
+      # General-purpose subnet
+      - name: reserved
+        address_prefix: 10.200.1.0/24
+        service_endpoints:
+          - Microsoft.Storage
+
+      # Container Apps subnet (requires delegation)
+      - name: apps
+        address_prefix: 10.200.2.0/24
+        delegation: Microsoft.App/environments
+        service_endpoints:
+          - Microsoft.Storage
+          - Microsoft.KeyVault
+
+      # PostgreSQL Flexible Server subnet
+      - name: psql
+        address_prefix: 10.200.3.0/24
+        delegation: Microsoft.DBforPostgreSQL/flexibleServers
+        service_endpoints:
+          - Microsoft.Storage
+
+      # Azure Firewall subnet (must be named AzureFirewallSubnet)
+      - name: AzureFirewallSubnet
+        address_prefix: 10.200.128.0/26
+
+      # Azure Firewall management subnet (required for Basic SKU)
+      - name: AzureFirewallManagementSubnet
+        address_prefix: 10.200.128.64/26
+
+      # VPN Gateway subnet
+      - name: GatewaySubnet
+        address_prefix: 10.200.241.0/27
+
+  # Public DNS zone
+  dns_zone:
+    name: example.graviton.dev
+
+  # Private DNS zones for private endpoints
+  # NOTE: linked_vnets is optional. When specified, it links the private DNS
+  # zone to remote VNets (e.g., spoke networks). The hub VNet created by this
+  # stack is linked automatically by the base — no self-reference needed.
+  private_dns_zones:
+    - name: privatelink.postgres.database.azure.com

--- a/development/04-networking/Pulumi.yaml
+++ b/development/04-networking/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: networking
+description: Hub-Spoke Virtual Network with subnets, DNS zones, and private DNS
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/04-networking/__main__.py
+++ b/development/04-networking/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Hub-Spoke Network"""
+
+import os
+
+from orbitcloud_graviton.hubspoke import deploy_hub_spoke
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy_hub_spoke()

--- a/development/05-firewall/Pulumi.dev.yaml
+++ b/development/05-firewall/Pulumi.dev.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: fw
+
+  firewall:
+    sku: Basic
+    # Firewall subnet from the networking stack
+    subnet: stack://networking/dev/subnets.AzureFirewallSubnet.id
+    # Management subnet required for Basic SKU
+    management_subnet: stack://networking/dev/subnets.AzureFirewallManagementSubnet.id
+
+  # Enable Log Analytics workspace for firewall diagnostics
+  log: true

--- a/development/05-firewall/Pulumi.yaml
+++ b/development/05-firewall/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: firewall
+description: Azure Firewall with rule collection groups
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/05-firewall/__main__.py
+++ b/development/05-firewall/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Azure Firewall"""
+
+import os
+
+from orbitcloud_graviton.firewall import deploy_firewall
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy_firewall()

--- a/development/06-app-zone/Pulumi.dev.yaml
+++ b/development/06-app-zone/Pulumi.dev.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: apps
+
+  # Container App Environment — runs on the apps subnet from networking
+  containerapp_env:
+    subnet_id: stack://networking/dev/subnets.apps.id
+    public_network_access: true
+
+  # Key Vault for application secrets
+  keyvault:
+    public_network_access: Enabled
+    allowed_public_networks:
+      - 203.0.113.0/24 # RFC 5737 — replace with your office IP range

--- a/development/06-app-zone/Pulumi.yaml
+++ b/development/06-app-zone/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: app_zone
+description: Container App Environment — App Insights, Key Vault, optional Service Bus
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/06-app-zone/__main__.py
+++ b/development/06-app-zone/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Container App Environment (App Zone)"""
+
+import os
+
+from orbitcloud_graviton.app_zone import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/07-app-workload-http/Pulumi.dev.yaml
+++ b/development/07-app-workload-http/Pulumi.dev.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: web-api
+
+  apps:
+    - # Reference the Container App Environment from the app-zone stack
+      environment_output_ref: stack://app_zone/dev/containerapp_env
+      workload_profile_name: Consumption
+
+      containers:
+        - name: web-api
+          image: mcr.microsoft.com/k8se/quickstart:latest
+
+      ingress:
+        external: true
+        protocol: http
+        target_port: 80
+        ip_allow_list:
+          - 203.0.113.0/24 # RFC 5737 — replace with your office IP range
+
+      scaling:
+        min_replicas: 1
+        max_replicas: 5
+        rules:
+          http-trigger:
+            rule_type: http
+            concurrent_requests: 50

--- a/development/07-app-workload-http/Pulumi.yaml
+++ b/development/07-app-workload-http/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: app_workload_http
+description: App Workload — HTTP-triggered Container App with ingress and scaling
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/07-app-workload-http/__main__.py
+++ b/development/07-app-workload-http/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: App Workload — HTTP-triggered Container App"""
+
+import os
+
+from orbitcloud_graviton.app_workload import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/08-app-workload-job-scheduled/Pulumi.dev.yaml
+++ b/development/08-app-workload-job-scheduled/Pulumi.dev.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: job-scheduled
+
+  jobs:
+    - environment_output_ref: stack://app_zone/dev/containerapp_env
+      workload_profile_name: Consumption
+
+      trigger:
+        trigger_type: Schedule
+        replica_timeout_seconds: 60
+        cron: "0 */1 * * *" # Execute every hour
+
+      containers:
+        - name: scheduled-task
+          image: mcr.microsoft.com/k8se/quickstart-jobs:latest

--- a/development/08-app-workload-job-scheduled/Pulumi.yaml
+++ b/development/08-app-workload-job-scheduled/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: app_workload_job_scheduled
+description: App Workload — Scheduled (cron) Container App Job
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/08-app-workload-job-scheduled/__main__.py
+++ b/development/08-app-workload-job-scheduled/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: App Workload — Scheduled (cron) Container App Job"""
+
+import os
+
+from orbitcloud_graviton.app_workload import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/09-app-workload-job-event/Pulumi.dev.yaml
+++ b/development/09-app-workload-job-event/Pulumi.dev.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: job-event
+
+  jobs:
+    - environment_output_ref: stack://app_zone/dev/containerapp_env
+      workload_profile_name: Consumption
+
+      trigger:
+        trigger_type: Event
+        replica_timeout_seconds: 60
+        scale:
+          rules:
+            queuetrigger:
+              rule_type: azure-queue
+              metadata:
+                # IMPORTANT: accountName must match the actual deployed storage
+                # account name. The CDK applies naming conventions (prefix, env,
+                # location) so this will differ from the config `name` below.
+                # Run `pulumi stack output` on this stack after deploying to get
+                # the real name, e.g. "steventdevneu01".
+                accountName: steventdevneu01
+                queueName: tasks
+                queueLength: 5
+                queueLengthStrategy: visibleonly
+
+      containers:
+        - name: queue-processor
+          image: mcr.microsoft.com/k8se/quickstart-jobs:latest
+
+  # Storage account providing the queue trigger source
+  storage_accounts:
+    - name: event
+      sku: Standard_LRS
+      public_network_access: Enabled
+      allowed_private_subnets:
+        - stack://networking/dev/subnets.apps.id
+      allowed_public_ips:
+        - 203.0.113.1 # RFC 5737 — replace with your office IP
+      storage_containers:
+        - eventdata
+      storage_queues:
+        - tasks
+      app_permissions:
+        blobs:
+          contributor: true
+        queues:
+          contributor: true

--- a/development/09-app-workload-job-event/Pulumi.yaml
+++ b/development/09-app-workload-job-event/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: app_workload_job_event
+description: App Workload — Event-driven Container App Job (queue/blob trigger)
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/09-app-workload-job-event/__main__.py
+++ b/development/09-app-workload-job-event/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: App Workload — Event-driven Container App Job (queue trigger)"""
+
+import os
+
+from orbitcloud_graviton.app_workload import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/10-azuresql/Pulumi.dev.yaml
+++ b/development/10-azuresql/Pulumi.dev.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: sqldb
+
+  server:
+    # Entra-only authentication (no SQL admin password needed)
+    azure_ad_only_authentication: true
+    entra_admin:
+      # Replace with a real Entra group or user object ID
+      principal_type: Group
+      sid: "22222222-2222-2222-2222-222222222222"
+      login_name: sql-admins
+
+    # Network access — restrict to private subnet for production
+    public_network_access: Enabled
+    allow_azure_services: true
+
+  databases:
+    - name: appdb
+      max_size_mb: 2048
+      backup_redundancy: Local

--- a/development/10-azuresql/Pulumi.yaml
+++ b/development/10-azuresql/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: azuresql
+description: Azure SQL Server with Entra-only auth and sample database
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/10-azuresql/__main__.py
+++ b/development/10-azuresql/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Azure SQL Server + Database"""
+
+import os
+
+from orbitcloud_graviton.azuresql import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/11-appservice-suite/Pulumi.dev.yaml
+++ b/development/11-appservice-suite/Pulumi.dev.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: asp
+
+  # Enable Log Analytics workspace
+  include_log_workspace: true
+
+  # Enable Key Vault for app secrets
+  include_keyvault: true

--- a/development/11-appservice-suite/Pulumi.yaml
+++ b/development/11-appservice-suite/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: appservice_suite
+description: App Service Plan for hosting web apps and function apps
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/11-appservice-suite/__main__.py
+++ b/development/11-appservice-suite/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: App Service Plan"""
+
+import os
+
+from orbitcloud_graviton.appservice_suite import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/12-workload-identities/Pulumi.dev.yaml
+++ b/development/12-workload-identities/Pulumi.dev.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: wlid
+
+  identities:
+    # GitHub Actions OIDC federation
+    - workload:
+        credential_type: github
+        github_org: example-org
+        repo: example-app
+        environments:
+          - dev
+          - staging
+
+      # Azure permissions granted to this workload identity
+      azure_permissions:
+        - name_prefix: acr-push
+          role: AcrPush
+          scope: stack://landing_zone/dev/container_registry.id
+
+        - name_prefix: app-deploy
+          role: Container Apps Contributor
+          scope: "/subscriptions/11111111-1111-1111-1111-111111111111"

--- a/development/12-workload-identities/Pulumi.yaml
+++ b/development/12-workload-identities/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: workload_identities
+description: Federated credentials for CI/CD pipelines (GitHub Actions, Azure DevOps)
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/12-workload-identities/__main__.py
+++ b/development/12-workload-identities/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Workload Identities — Federated credentials for CI/CD"""
+
+import os
+
+from orbitcloud_graviton.workload_identities import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/13-oauth-apps/Pulumi.dev.yaml
+++ b/development/13-oauth-apps/Pulumi.dev.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: oauth
+
+  oauth_apps:
+    # Example: SPA frontend application
+    - name: frontend-spa
+      authentication:
+        redirect_uris:
+          - https://example.graviton.dev/auth/callback
+          - http://localhost:3000/auth/callback
+        logout_url: https://example.graviton.dev/auth/logout
+
+    # Example: Backend API with client credentials
+    - name: backend-api
+      client_credentials:
+        - display_name: api-secret

--- a/development/13-oauth-apps/Pulumi.yaml
+++ b/development/13-oauth-apps/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: oauth_apps
+description: OAuth/OIDC app registrations in Entra ID
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/13-oauth-apps/__main__.py
+++ b/development/13-oauth-apps/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: OAuth/OIDC App Registrations"""
+
+import os
+
+from orbitcloud_graviton.oauth_apps import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/14-entra-external-id/Pulumi.dev.yaml
+++ b/development/14-entra-external-id/Pulumi.dev.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=.stack_schema.json
+# NOTE: The CIAM Azure API does not support service principal auth.
+# You must run this stack with interactive (az login) credentials.
+config:
+  azure-native:location: northeurope
+  azure-native:subscriptionId: "11111111-1111-1111-1111-111111111111"
+  azure-native:tenantId: "00000000-0000-0000-0000-000000000000"
+  azuread:tenantId: "00000000-0000-0000-0000-000000000000"
+  workload_name: externalusers
+  env: dev
+
+  tenant:
+    location: Europe
+    country_code: IS
+    display_name: Graviton Users (dev)
+    # Prefix only — Azure appends .onmicrosoft.com automatically
+    initial_domain_prefix: gravitonusersdev

--- a/development/14-entra-external-id/Pulumi.yaml
+++ b/development/14-entra-external-id/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: entra_external_id
+description: Entra External ID (B2C) tenant for customer-facing authentication
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/14-entra-external-id/__main__.py
+++ b/development/14-entra-external-id/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Entra External ID (B2C) tenant"""
+
+import os
+
+from orbitcloud_graviton.entra_external_id import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/15-acme-ssl/Pulumi.dev.yaml
+++ b/development/15-acme-ssl/Pulumi.dev.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: cert
+
+  cert_request:
+    # DNS zone must exist (see 03-landing-zone or 04-networking)
+    dns_zone_name: example.graviton.dev
+    acme_account_email: admin@example.com
+    # Optional: store the certificate in Key Vault
+    # keyvault_id: stack://landing_zone/dev/keyvault.id

--- a/development/15-acme-ssl/Pulumi.yaml
+++ b/development/15-acme-ssl/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: acme_ssl
+description: Let's Encrypt ACME wildcard certificate with Azure DNS validation
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/15-acme-ssl/__main__.py
+++ b/development/15-acme-ssl/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Let's Encrypt ACME wildcard certificates"""
+
+import os
+
+from orbitcloud_graviton.acme_ssl import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/16-oracledb/Pulumi.dev.yaml
+++ b/development/16-oracledb/Pulumi.dev.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=.stack_schema.json
+environment:
+  - graviton-dev
+config:
+  workload_name: oradb
+  env: dev
+
+  vm:
+    sku: Standard_E4ds_v6
+    zone: "1"
+
+    os:
+      image:
+        publisher: Oracle
+        offer: Oracle-Linux
+        sku: ol94-lvm-gen2
+        version: latest
+      disk:
+        size_gb: 100
+      admin:
+        authorized_ssh_keys:
+          - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample000000000000000000000000000000 example@graviton"
+      hostname: oradb-dev
+
+    # Data disks for Oracle tablespaces
+    storage:
+      - name: oracle-base
+        size_gb: 100
+        lun: 0
+        mount_point: /opt/oracle/
+
+      - name: oradata
+        size_gb: 500
+        lun: 1
+        mount_point: /oradata/main
+
+      - name: oraredo1
+        size_gb: 64
+        lun: 2
+        mount_point: /oradata/redo1
+
+    # Subnet for the VM NIC
+    networking:
+      subnet_id: stack://networking/dev/subnets.reserved.id
+
+  cloud_init:
+    mount_point_base: /mnt
+    timezone: UTC
+
+  # Backup storage account with file shares for RMAN backups
+  backup:
+    storage:
+      name: gvtnorabackupdev
+      file_shares:
+        - name: orabackups
+      public_network_access: Enabled
+      allowed_private_subnets:
+        - stack://networking/dev/subnets.reserved.id

--- a/development/16-oracledb/Pulumi.yaml
+++ b/development/16-oracledb/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: oracledb
+description: Oracle Database VM with cloud-init, data disks, and backup storage
+runtime:
+  name: python
+options:
+  refresh: always

--- a/development/16-oracledb/__main__.py
+++ b/development/16-oracledb/__main__.py
@@ -1,0 +1,13 @@
+"""Graviton Example: Oracle Database on Azure VM"""
+
+import os
+
+from orbitcloud_graviton.oracledb import deploy
+
+if __name__ == "__main__":
+    if os.environ.get("PULUMI_DEBUG") == "true":
+        import debugpy  # type: ignore
+
+        debugpy.listen(5678)
+        debugpy.wait_for_client()
+    deploy()

--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,80 @@
+# Graviton CDK - Example Stacks
+
+This directory contains example Pulumi stacks demonstrating every stack type available
+in the Graviton CDK. These serve as both documentation and integration test targets.
+
+## Prerequisites
+
+- Python 3.12+
+- [Poetry](https://python-poetry.org/) installed
+- [Pulumi CLI](https://www.pulumi.com/docs/install/) installed
+- Azure CLI (`az login`) with an active session
+- A Pulumi account and organization
+
+## Setup
+
+```bash
+cd development/
+poetry install
+```
+
+## Placeholder Values
+
+All examples use placeholder values that must be replaced before deployment:
+
+| Value | Placeholder | Replace With |
+|-------|------------|--------------|
+| Tenant ID | `00000000-0000-0000-0000-000000000000` | Your Azure AD tenant ID |
+| Subscription ID | `11111111-1111-1111-1111-111111111111` | Your Azure subscription ID |
+| Location | `northeurope` | Your preferred Azure region |
+| ESC Environment | `graviton-dev` | Your Pulumi ESC environment name |
+| IP allow list | `203.0.113.0/24` | Your office/VPN IP range |
+| Domain name | `example.graviton.dev` | Your DNS domain |
+
+## Deployment Order
+
+Stacks should be deployed in numerical order, as later stacks may reference
+outputs from earlier ones via `stack://` references.
+
+```
+01-tenant          # Azure Tenant configuration (Pulumi ESC)
+02-environment     # Azure Environment (Pulumi ESC OIDC credentials)
+03-landing-zone    # Log Analytics, Key Vault, Container Registry
+04-networking      # Hub-Spoke Virtual Network
+05-firewall        # Azure Firewall (requires networking subnets)
+06-app-zone        # Container App Environment, Key Vault, App Insights
+07-app-workload-http           # HTTP-triggered Container App
+08-app-workload-job-scheduled  # Scheduled (cron) Container App Job
+09-app-workload-job-event      # Event-driven Container App Job (queue trigger)
+10-azuresql        # Azure SQL Server + Database
+11-appservice-suite # App Service Plan
+12-workload-identities # Federated credentials for CI/CD
+13-oauth-apps      # OAuth/OIDC app registrations
+14-entra-external-id # Entra External ID (B2C) tenant
+15-acme-ssl        # Let's Encrypt ACME wildcard certificates
+16-oracledb        # Oracle Database on Azure VM
+```
+
+## Deploying a Single Stack
+
+```bash
+cd 07-app-workload-http/
+pulumi up --stack dev
+```
+
+## Debugging
+
+Each `__main__.py` includes support for the `PULUMI_DEBUG` environment variable.
+Set it to `true` to enable debugpy on port 5678:
+
+```bash
+PULUMI_DEBUG=true pulumi up --stack dev
+```
+
+Then attach your IDE debugger to `localhost:5678`.
+
+## Schema Validation
+
+Each `Pulumi.dev.yaml` includes a `yaml-language-server` schema reference.
+Run `pulumi preview` once to generate the `.stack_schema.json` file, then
+your IDE will provide autocompletion and validation for the config values.

--- a/development/pyproject.toml
+++ b/development/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+authors = ["Graviton CDK <admin@example.com>"]
+description = "Graviton CDK example stacks for development and integration testing"
+name = "graviton-examples"
+package-mode = false
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+orbitcloud-graviton = { path = "..", develop = true }
+python = ">=3.12,<4.0"
+
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]

--- a/docs/requirements/stack-examples/README.md
+++ b/docs/requirements/stack-examples/README.md
@@ -1,0 +1,220 @@
+# Stack Examples Requirements
+
+## Overview
+
+Create a comprehensive set of example Pulumi stacks in the `development/` folder that demonstrate how to configure and deploy every stack type available in Graviton. These examples serve two purposes:
+
+1. **Documentation/Demonstration** — Show developers how to configure each stack type with realistic, well-commented configurations
+2. **Integration Testing** — Provide deployable stacks that can be run against a real Azure subscription to validate the Graviton CDK
+
+## Goals
+
+- Cover all 14 stack types with at least one working example each
+- Use placeholder Azure tenant/subscription values (to be replaced with real values when deploying)
+- Follow existing project conventions (Copier template patterns, schema generation, debug support)
+- Keep examples minimal but realistic — enough config to demonstrate the stack, not so much that it obscures the pattern
+- Each example should be independently deployable via `pulumi up`
+
+## User Stories
+
+- As a **new Graviton user**, I want to see working examples of every stack type so that I can understand how to configure my own infrastructure
+- As a **Graviton contributor**, I want to run example stacks against Azure so that I can validate changes don't break real deployments
+- As a **platform engineer**, I want reference configurations I can copy and adapt for new customer projects
+
+## Directory Structure
+
+```
+development/
+├── pyproject.toml                    # Shared Python/Poetry config for all examples
+├── poetry.lock
+├── README.md                         # Overview and usage instructions
+│
+├── 01-tenant/                        # Azure Tenant configuration
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 02-environment/                   # Azure Environment (Pulumi ESC)
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 03-landing-zone/                  # Landing Zone (Log Analytics, Key Vault, etc.)
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 04-networking/                    # Hub-Spoke Network
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 05-firewall/                      # Azure Firewall
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 06-app-zone/                      # Container App Environment
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 07-app-workload-http/             # App Workload — HTTP-triggered container app
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 08-app-workload-job-scheduled/    # App Workload — Scheduled (cron) job
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 09-app-workload-job-event/        # App Workload — Event-driven job (queue/blob trigger)
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 10-azuresql/                      # Azure SQL Server + Database
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 11-appservice-suite/              # App Service Plan
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 12-workload-identities/           # Federated credentials for CI/CD
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 13-oauth-apps/                    # OAuth/OIDC app registrations
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 14-entra-external-id/             # Entra External ID (B2C)
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+├── 15-acme-ssl/                      # Let's Encrypt ACME certificates
+│   ├── Pulumi.yaml
+│   ├── Pulumi.dev.yaml
+│   └── __main__.py
+│
+└── 16-oracledb/                      # Oracle DB on Azure VM
+    ├── Pulumi.yaml
+    ├── Pulumi.dev.yaml
+    └── __main__.py
+```
+
+**Numbering rationale:** Numbers reflect a natural deployment order (tenant first, then environment, then landing zone, networking, etc.). App workloads are split into 3 variants (HTTP, scheduled job, event-driven job) as requested — one example per distinct workload pattern.
+
+## Functional Requirements
+
+### Must Have (P0)
+
+- [ ] **All 14 stack types covered** — One example directory per base, plus 3 app workload variants (16 total)
+- [ ] **Standard project structure per example** — Each directory contains `Pulumi.yaml`, `Pulumi.dev.yaml`, and `__main__.py` following the Copier template pattern
+- [ ] **Placeholder Azure values** — Use clearly fake but structurally valid UUIDs for tenant/subscription IDs (e.g., `00000000-0000-0000-0000-000000000000`)
+- [ ] **Schema validation support** — Each `Pulumi.dev.yaml` includes `# yaml-language-server: $schema=.stack_schema.json` header
+- [ ] **Minimal but complete configs** — Each stack config includes all required fields and a representative sample of optional fields to demonstrate capabilities
+- [ ] **Debug support** — Each `__main__.py` includes the standard `PULUMI_DEBUG` / debugpy pattern used in customer projects
+- [ ] **Shared pyproject.toml** — Single Poetry config at `development/` root with `orbitcloud_graviton` as a path dependency
+- [ ] **README.md at root** — Documents the purpose, prerequisites, and how to deploy each example
+
+### Should Have (P1)
+
+- [ ] **Comments in config files** — Brief inline comments in `Pulumi.dev.yaml` explaining what key config values do
+- [ ] **Cross-stack references** — Where stacks naturally reference each other (e.g., app-workload referencing app-zone), use `stack://` reference syntax to demonstrate the pattern
+- [ ] **Realistic resource naming** — Use a consistent naming convention (e.g., `graviton-dev` prefix) that mirrors real-world patterns
+
+### Nice to Have (P2)
+
+- [ ] **CI/CD integration** — GitHub Actions workflow to deploy/destroy examples against a test subscription
+- [ ] **Deployment ordering script** — Simple script that deploys all stacks in dependency order
+
+## Non-Functional Requirements
+
+- **Security:** No real secrets, tenant IDs, subscription IDs, IP addresses, or customer-specific values committed. All sensitive values must be clearly placeholder.
+- **Backwards Compatibility:** Not applicable (new directory, no existing code affected)
+- **Maintainability:** Examples should import and call the base `deploy()` functions directly — no custom Pulumi resource code in examples. When a base changes, examples automatically reflect it.
+
+## Placeholder Values Convention
+
+Use these consistent placeholder values across all examples:
+
+| Value | Placeholder |
+|-------|------------|
+| Tenant ID | `00000000-0000-0000-0000-000000000000` |
+| Subscription ID | `11111111-1111-1111-1111-111111111111` |
+| Location | `northeurope` |
+| Environment | `dev` |
+| ESC Environment | `graviton-dev` |
+| Workload prefix | `gvtn` (short for graviton) |
+| IP allow list | `203.0.113.0/24` (RFC 5737 documentation range) |
+| SSH public key | `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample... example@graviton` |
+| Domain name | `example.graviton.dev` |
+| VNet address space | `10.200.0.0/16` |
+| Subnet prefixes | `10.200.x.0/24` |
+
+## Edge Cases & Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `pulumi preview` with placeholder values | Should succeed structurally (schema validation passes) even without real Azure credentials |
+| Missing ESC environment | Stacks that reference ESC should document this dependency clearly in comments |
+| Cross-stack references to non-existent stacks | Should be documented with comments explaining which stack must be deployed first |
+| Oracle DB cloud-init | Should include a minimal cloud-init template without real Oracle licenses or proprietary config |
+
+## Affected Components/Bases
+
+No modifications to existing bases or components. This creates **new content only** under `development/`.
+
+All 14 bases are consumed (read-only) by the examples:
+- `bases/orbitcloud_graviton/azure_tenant/`
+- `bases/orbitcloud_graviton/azure_environment/`
+- `bases/orbitcloud_graviton/landing_zone/`
+- `bases/orbitcloud_graviton/hubspoke/`
+- `bases/orbitcloud_graviton/firewall/`
+- `bases/orbitcloud_graviton/app_zone/`
+- `bases/orbitcloud_graviton/app_workload/`
+- `bases/orbitcloud_graviton/azuresql/`
+- `bases/orbitcloud_graviton/appservice_suite/`
+- `bases/orbitcloud_graviton/workload_identities/`
+- `bases/orbitcloud_graviton/oauth_apps/`
+- `bases/orbitcloud_graviton/entra_external_id/`
+- `bases/orbitcloud_graviton/acme_ssl/`
+- `bases/orbitcloud_graviton/oracledb/`
+
+## Out of Scope
+
+- Modifying any existing base or component code
+- Creating new Pulumi components or bases
+- Real Azure deployments (that's a follow-up activity using these examples)
+- Pulumi ESC environment setup (documented as a prerequisite)
+- CI/CD pipeline implementation (P2 nice-to-have, separate effort)
+
+## Dependencies
+
+- All 14 Graviton bases must be importable (they already exist)
+- Python 3.11+ with Poetry
+- Pulumi CLI installed
+- For actual deployment: Azure subscription, Pulumi ESC environment, and `az login` session
+
+## Open Questions
+
+- [ ] Should the `development/` folder share the repo-root `pyproject.toml` or have its own? (Recommendation: own `pyproject.toml` with path dependency on `orbitcloud_graviton` to mirror how customer projects work)
+- [ ] Do we want multiple stack variants per example (e.g., `Pulumi.dev.yaml` AND `Pulumi.prod.yaml`) or just `dev`? (Recommendation: just `dev` to keep it simple)
+
+## Acceptance Criteria
+
+1. All 16 example directories exist under `development/` with the correct file structure
+2. Each `__main__.py` imports from the correct base and calls `deploy()`
+3. Each `Pulumi.dev.yaml` contains valid configuration for its stack type with placeholder values
+4. No real customer-specific values (tenant IDs, subscription IDs, names, IPs) are present
+5. `development/README.md` documents prerequisites and deployment order
+6. `pyproject.toml` at `development/` root has `orbitcloud_graviton` as a dependency
+7. `pulumi preview` succeeds structurally for each stack (schema validation, config parsing) when run with appropriate Azure credentials

--- a/docs/requirements/stack-examples/SUMMARY.md
+++ b/docs/requirements/stack-examples/SUMMARY.md
@@ -1,0 +1,72 @@
+# Stack Examples - Implementation Summary
+
+## What was implemented
+
+Created 16 example Pulumi project directories under `development/`, plus shared configuration files, covering all 14 Graviton CDK base stack types (with 3 app workload variants).
+
+### Shared files
+- `development/pyproject.toml` -- Poetry config with `orbitcloud-graviton` as a path dependency to the monorepo root
+- `development/README.md` -- Documentation covering prerequisites, placeholder values, deployment order, debugging, and schema validation
+
+### Example directories (16 total)
+
+Each directory contains `Pulumi.yaml`, `Pulumi.dev.yaml`, and `__main__.py`:
+
+| # | Directory | Base | Key Config |
+|---|-----------|------|------------|
+| 01 | `01-tenant` | `azure_tenant` | Customer info, ESC env, global tags, IP allow list |
+| 02 | `02-environment` | `azure_environment` | ESC OIDC credentials, subscription binding, imports |
+| 03 | `03-landing-zone` | `landing_zone` | Key Vault, Container Registry, DNS zone, ACME SSL |
+| 04 | `04-networking` | `hubspoke` | VNet with 6 subnets (apps, psql, firewall, gateway), DNS zones |
+| 05 | `05-firewall` | `firewall` | Basic SKU with management subnet, log analytics |
+| 06 | `06-app-zone` | `app_zone` | Container App Environment on apps subnet, Key Vault |
+| 07 | `07-app-workload-http` | `app_workload` | HTTP Container App with ingress and scaling rules |
+| 08 | `08-app-workload-job-scheduled` | `app_workload` | Cron-triggered Container App Job |
+| 09 | `09-app-workload-job-event` | `app_workload` | Queue-triggered Container App Job with storage account |
+| 10 | `10-azuresql` | `azuresql` | SQL Server with Entra-only auth and sample database |
+| 11 | `11-appservice-suite` | `appservice_suite` | App Service Plan with Log Analytics and Key Vault |
+| 12 | `12-workload-identities` | `workload_identities` | GitHub Actions OIDC federation with Azure permissions |
+| 13 | `13-oauth-apps` | `oauth_apps` | SPA and backend API app registrations |
+| 14 | `14-entra-external-id` | `entra_external_id` | B2C tenant for customer-facing auth |
+| 15 | `15-acme-ssl` | `acme_ssl` | Let's Encrypt wildcard certificate via Azure DNS |
+| 16 | `16-oracledb` | `oracledb` | Oracle Linux VM with data disks and backup storage |
+
+## Tests added
+
+None -- these are configuration/example files, not library code. The examples are validated by `make fmt && make lint` passing.
+
+## Design decisions and trade-offs
+
+1. **`__main__.py` pattern**: Every example uses the `PULUMI_DEBUG` / debugpy pattern from real customer projects, matching the convention in `~/src/customer-infra-projects/`.
+
+2. **Config derived from source code**: Each `Pulumi.dev.yaml` was written by reading the actual Pydantic `Config` models in each base, ensuring field names and types are correct. Customer project configs were used as reference for realistic values.
+
+3. **Placeholder values**: All examples use the placeholder convention from the requirements (tenant `00000000...`, subscription `11111111...`, IP `203.0.113.0/24`). No real customer values are present.
+
+4. **Cross-stack references**: Where stacks naturally depend on each other, `stack://` references are used (e.g., networking subnets referenced by firewall, app zone, and app workloads).
+
+5. **ESC environment pattern**: Stacks that would normally inherit config from Pulumi ESC use `environment: [graviton-dev]`. The tenant stack does not use an ESC import (it creates the ESC environment). The `14-entra-external-id` example documents that it cannot use ESC OIDC due to Azure API limitations.
+
+6. **Minimal but realistic**: Each config includes all required fields and a representative sample of optional fields -- enough to demonstrate the stack pattern without overwhelming the reader.
+
+## Issues encountered
+
+- The worktree did not have `poetry install` run yet, so `make fmt` initially failed. After `poetry install`, all validation passed cleanly.
+
+## Review 01 changes
+
+Addressed 4 issues from code review:
+
+1. **Unique project names** -- Renamed `Pulumi.yaml` project names for the three app workload variants from the shared `app_workloads` to `app_workload_http`, `app_workload_job_scheduled`, and `app_workload_job_event` to avoid Pulumi backend conflicts.
+
+2. **initial_domain_prefix** -- Fixed `14-entra-external-id/Pulumi.dev.yaml` to use just the prefix (`gravitonusersdev`) instead of the full domain (`gravitonusersdev.onmicrosoft.com`). The Azure CIAM API expects only the subdomain prefix.
+
+3. **Networking self-reference** -- Removed the `linked_vnets: [stack://networking/dev/vnet.id]` self-reference from `04-networking/Pulumi.dev.yaml`. Added a comment explaining that `linked_vnets` is for remote VNets and the hub VNet is linked automatically by the base.
+
+4. **KEDA accountName** -- Fixed `09-app-workload-job-event/Pulumi.dev.yaml` to use the CDK-generated storage account name (`steventdevne01`) instead of the config input name. Simplified storage account config `name` from `gvtneventdev` to `event`. Added a comment explaining the CDK naming convention.
+
+## Suggested next steps
+
+1. **Deploy and validate**: Run `pulumi preview` for each stack against a test Azure subscription to verify config parsing works end-to-end.
+2. **P2 items**: Add a GitHub Actions workflow and deployment ordering script as described in the requirements.
+3. **Schema generation**: Run each stack once to generate `.stack_schema.json` files for IDE autocompletion support.

--- a/docs/requirements/stack-examples/review-01.md
+++ b/docs/requirements/stack-examples/review-01.md
@@ -1,0 +1,124 @@
+# Review 01
+
+> Status: addressed
+> Date: 2026-03-03
+> Reviewer: Code Review Agent
+> Verdict: REQUEST CHANGES
+
+## Previous Review Status
+
+No previous reviews.
+
+## New Findings
+
+### Critical (Must Fix)
+
+1. **[development/01-tenant/Pulumi.dev.yaml]** The `AzureTenantConfig.esc` field expects a `PulumiEnvConfig` object, which has a required `env_name` field and no other required fields. The example correctly provides `esc.env_name: graviton-dev`. However, `AzureTenantConfig` extends `PulumiConfig` (a `BaseSettings` subclass with `extra="forbid"`), and the config includes `azuread:tenantId` which is read by Pulumi's own config system, not by Pydantic. This is fine -- Pulumi config keys with a namespace prefix (containing `:`) are handled separately.
+
+   **On closer inspection, this is NOT a critical issue.** The `PulumiConfigSettingsSource` splits on `:` to determine the config bag, so `azuread:tenantId` is read from the `azuread` bag, not from the root config. The tenant config also reads `env`, `customer`, `esc`, and `globals` from the root bag -- all present in the YAML. No actual issue here.
+
+   _(Retracted -- see Important items below for actual findings.)_
+
+2. **[development/14-entra-external-id/Pulumi.dev.yaml:16]** The `initial_domain_prefix` value is `gravitonusersdev.onmicrosoft.com`. The field name says "prefix" but the value is a full domain including `.onmicrosoft.com`. Review the `ExternalIdTenantConfig` and its usage to determine whether this should be just the prefix (e.g., `gravitonusersdev`) or the full domain. Looking at the model, the field is `initial_domain_prefix: str` with no validation, so it depends on how it is used downstream. If the Azure API expects just the prefix, this value would cause deployment failure.
+
+### Important (Should Fix)
+
+1. **[development/01-tenant/Pulumi.dev.yaml]** Missing `workload_name` in comments context. While `workload_name` is present (line 4), the config sets `env: graviton-dev` which is the ESC environment name, not the typical environment short name like `dev`. This is intentional for the tenant stack (since `env` in `AzureTenantConfig` is used as the ESC environment name in the `PulumiEnv` call), but it could confuse readers. Consider adding a comment explaining that `env` here refers to the ESC environment name, not the deployment environment.
+
+2. **[development/07-app-workload-http/Pulumi.yaml, 08/Pulumi.yaml, 09/Pulumi.yaml]** All three app workload variant directories use the same Pulumi project `name: app_workloads`. This will cause conflicts if a user tries to deploy more than one of these in the same Pulumi backend organization, because Pulumi identifies projects by name. Each should have a unique project name, e.g.:
+   - `07`: `app_workload_http`
+   - `08`: `app_workload_job_scheduled`
+   - `09`: `app_workload_job_event`
+
+3. **[development/README.md:8]** The README states Python 3.12+ is required, but the requirements document says Python 3.11+ and the `pyproject.toml` says `python = ">=3.12,<4.0"`. The pyproject.toml and README are consistent with each other (3.12+), but they differ from the requirements doc. This is fine as long as 3.12 is the intended minimum -- just noting the discrepancy with the requirements doc.
+
+4. **[development/04-networking/Pulumi.dev.yaml:53]** The `private_dns_zones` entry uses `linked_vnets` with a `stack://networking/dev/vnet.id` reference. This is a self-reference (the networking stack referencing its own output). While Pulumi stack references to the same stack technically work, this is unusual and potentially confusing. In practice the VNet ID would be available locally without a stack reference. Consider either removing the `linked_vnets` or referencing it with a comment explaining this is a self-reference pattern for demonstration purposes.
+
+5. **[development/09-app-workload-job-event/Pulumi.dev.yaml:19]** The `accountName: gvtneventdev` in the KEDA queue trigger metadata must match the actual storage account name. The storage account config below defines `name: gvtneventdev`. However, Azure storage account names are globally unique and have a 24-character limit with only lowercase letters and numbers. The name `gvtneventdev` (12 chars) is valid but the Graviton CDK may prepend a prefix to it. Verify that the KEDA metadata `accountName` will match the actual deployed storage account name after any prefixing by the CDK.
+
+### Suggestions (Consider)
+
+1. **[development/pyproject.toml]** Consider pinning the Poetry version or adding a `tool.poetry.group.dev.dependencies` section with `debugpy` listed explicitly, since all `__main__.py` files import it conditionally. Currently `debugpy` would need to be installed separately, which a reader might not realize.
+
+2. **[development/11-appservice-suite/Pulumi.dev.yaml]** This is the most minimal config of all 16 examples -- it only sets `include_log_workspace: true` and `include_keyvault: true`, which are already the defaults in `AppserviceSuiteConfig`. Consider either removing these (to show that defaults work) or adding at least one non-default field (like `log_workspace_ref_id` with a stack reference) to demonstrate the stack's configuration surface better.
+
+3. **[development/16-oracledb/Pulumi.dev.yaml]** The `env: dev` is explicitly set even though ESC-imported stacks normally get `env` from the ESC config. This is fine (explicit is better than implicit), but it is inconsistent with other ESC-using stacks (e.g., 06, 07, 08) which omit `env` entirely and rely on the ESC import to provide it. Consider being consistent -- either always explicitly set it or always rely on ESC.
+
+4. **[development/13-oauth-apps/Pulumi.dev.yaml]** The `backend-api` OAuth app config only sets `client_credentials` but no `authentication` block. While `EntraAppAuthentication` has sensible defaults, showing at least the `audience` field for the API app would make this a more useful example for developers setting up API-to-API auth.
+
+5. **[development/10-azuresql/Pulumi.dev.yaml]** Consider adding a `log_workspace_id` with a stack reference to the landing zone, since `AzureSqlBaseConfig` supports it and diagnostic logging is a best practice for SQL Server. This would also demonstrate another cross-stack reference.
+
+6. **[All Pulumi.yaml files]** All examples set `options: refresh: always`. While this is a valid setting for development, it slows down deployments. Consider adding a comment noting this is a development convenience and should be removed for production use.
+
+### Praise
+
+- **Consistent structure across all 16 examples.** Every `__main__.py` follows the exact same pattern with the debugpy support, docstring, and import. This makes the examples easy to scan and understand.
+
+- **Correct import paths.** Every `__main__.py` imports the correct function from the correct base module. The function names match exactly (`deploy`, `deploy_landing_zone`, `deploy_hub_spoke`, `deploy_firewall`).
+
+- **Well-chosen placeholder values.** The use of RFC 5737 documentation range `203.0.113.0/24` for IP allow lists, structurally valid but obviously fake UUIDs, and `example.graviton.dev` for domains follows best practices for example code.
+
+- **Cross-stack references are realistic.** The `stack://` references (networking subnets referenced by firewall, app zone, and oracledb; landing zone outputs referenced by workload identities) demonstrate real dependency patterns that users would encounter.
+
+- **Config field names verified correct against Pydantic models.** After tracing each config key through the `PulumiConfigSettingsSource` into the base Config models and their sub-models:
+  - `FirewallConfig.sku`, `.subnet`, `.management_subnet` -- correct
+  - `ContainerAppEnvConfig.subnet_id`, `.public_network_access` -- correct
+  - `ContainerAppConfig.environment_output_ref`, `.workload_profile_name`, `.containers`, `.ingress`, `.scaling` -- correct
+  - `HttpIngressConfig.protocol`, `.target_port`, `.external`, `.ip_allow_list` -- correct
+  - `HttpScaleRule.rule_type`, `.concurrent_requests` -- correct
+  - `ContainerAppJobConfig.trigger` with `JobScheduledTrigger` and `JobEventTrigger` -- correct discriminator values
+  - `AzureQueueRule.metadata` fields (`accountName`, `queueName`, `queueLength`, `queueLengthStrategy`) -- correct
+  - `SqlServerConfig.azure_ad_only_authentication`, `.entra_admin`, `.public_network_access`, `.allow_azure_services` -- correct
+  - `SqlDatabaseConfig.name`, `.max_size_mb`, `.backup_redundancy` -- correct
+  - `ExternalIdTenantConfig.location`, `.country_code`, `.display_name`, `.initial_domain_prefix` -- correct field names
+  - `AcmeSslConfig.dns_zone_name`, `.acme_account_email` -- correct
+  - `VirtualMachineConfig.sku`, `.zone`, `.os`, `.storage`, `.networking` -- correct
+  - `StorageAccountConfig.name`, `.sku`, `.public_network_access`, `.allowed_private_subnets`, `.allowed_public_ips`, `.storage_containers`, `.storage_queues`, `.app_permissions` -- correct
+  - `WorkloadIdentityConfig.workload` (with `GitHubOIDCCredentials` discriminator), `.azure_permissions` -- correct
+  - `EntraAppConfig.name`, `.authentication`, `.client_credentials` -- correct
+
+- **README.md is practical and well-organized.** The deployment order table, debugging instructions, and placeholder value reference table are exactly what a new user needs.
+
+- **The `pyproject.toml` correctly uses a path dependency.** This mirrors how customer projects work -- a separate Poetry project that depends on the monorepo root package.
+
+## Summary
+
+**Overall assessment: REQUEST CHANGES**
+
+The implementation is thorough, well-structured, and demonstrates strong familiarity with the Graviton CDK codebase. Config field names have been verified correct against all 14 base Pydantic models and their nested sub-models. The examples use consistent placeholder values and follow project conventions faithfully.
+
+**Key concerns to address before merge:**
+
+1. **(Important)** The three app workload Pulumi projects share the same `name: app_workloads`, which will cause conflicts in a real Pulumi backend. Each needs a unique name.
+2. **(Important)** The `initial_domain_prefix` in 14-entra-external-id may include the `.onmicrosoft.com` suffix incorrectly -- verify against the Azure API expectation.
+3. **(Important)** The self-referencing `stack://` in networking private DNS zones is unusual and should be explained or replaced.
+4. **(Important)** The KEDA `accountName` in 09-app-workload-job-event may not match the actual deployed storage account name if the CDK applies naming prefixes.
+
+**Estimated effort to address feedback:** 30-60 minutes. All issues are config value changes, not structural.
+
+## Developer Response
+
+### Critical Items
+
+1. **[Retracted]** No action needed.
+
+2. **[initial_domain_prefix] Fixed.** Confirmed by reading `ExternalIdTenant._tenant()` which passes `initial_domain_prefix` directly to `CIAMTenant(resource_name_=...)`. The Azure CIAM API `resource_name_` parameter is the initial domain prefix (subdomain only), not the full `.onmicrosoft.com` domain. Changed value from `gravitonusersdev.onmicrosoft.com` to `gravitonusersdev` and added a clarifying comment.
+
+### Important Items
+
+1. **[env comment in 01-tenant] Acknowledged.** Valid observation but not actioned -- the tenant stack is a special case with well-known conventions. Adding a comment here would set a precedent for explaining every field in every stack, which conflicts with keeping examples minimal.
+
+2. **[Unique project names] Fixed.** Renamed Pulumi project names:
+   - `07-app-workload-http/Pulumi.yaml`: `app_workloads` -> `app_workload_http`
+   - `08-app-workload-job-scheduled/Pulumi.yaml`: `app_workloads` -> `app_workload_job_scheduled`
+   - `09-app-workload-job-event/Pulumi.yaml`: `app_workloads` -> `app_workload_job_event`
+
+3. **[README Python version] No action.** The reviewer confirmed pyproject.toml and README are consistent (3.12+). The requirements doc saying 3.11+ is a requirements doc imprecision, not an implementation bug.
+
+4. **[Networking self-reference] Fixed.** Removed the `linked_vnets` self-reference from the private DNS zone config. Added a comment explaining that `linked_vnets` is optional and used for remote VNets (e.g., spoke networks), and that the hub VNet is linked automatically by the base.
+
+5. **[KEDA accountName] Fixed.** Traced through `StorageAccount.__init__` -> `stack.name_for()` -> `resource_namer()` with the storage YAML metadata (prefix=`st`, alphanumeric=true, lowercase=true). The CDK generates names like `st{workload}{env}{location}{instance}`. Changed storage account config `name` from `gvtneventdev` to `event` (simpler, avoids redundant "dev" in name), and updated KEDA `accountName` to `steventdevne01` to match the CDK naming output. Added a comment explaining the naming relationship.
+
+### Suggestions
+
+All suggestions were reviewed and acknowledged. No changes made for this iteration -- they are valid improvements but not blocking issues. They can be addressed in a follow-up if desired.

--- a/docs/requirements/stack-examples/review-02.md
+++ b/docs/requirements/stack-examples/review-02.md
@@ -1,0 +1,54 @@
+# Review 02
+
+> Status: pending-dev
+> Date: 2026-03-03
+> Reviewer: Code Review Agent
+> Verdict: REQUEST CHANGES
+
+## Previous Review Status
+
+- [x] Issue from review-01, Critical #2: `initial_domain_prefix` had full domain instead of prefix only - FIXED. Value changed to `gravitonusersdev` with clarifying comment at `/Users/on/src/graviton-oss/.claude/worktrees/stack-examples/development/14-entra-external-id/Pulumi.dev.yaml:17`.
+- [x] Issue from review-01, Important #2: Three app workload projects shared the same Pulumi project name - FIXED. Each now has a unique name (`app_workload_http`, `app_workload_job_scheduled`, `app_workload_job_event`) in their respective `Pulumi.yaml` files.
+- [x] Issue from review-01, Important #4: Self-referencing `stack://` in networking private DNS zones - FIXED. The `linked_vnets` self-reference was removed and a clarifying comment was added at `/Users/on/src/graviton-oss/.claude/worktrees/stack-examples/development/04-networking/Pulumi.dev.yaml:50-52`.
+- [ ] Issue from review-01, Important #5: KEDA `accountName` may not match deployed storage account name - PARTIALLY FIXED, NEW BUG INTRODUCED (see below).
+
+## New Findings
+
+### Critical (Must Fix)
+
+1. **[`/Users/on/src/graviton-oss/.claude/worktrees/stack-examples/development/09-app-workload-job-event/Pulumi.dev.yaml:24`]** The KEDA `accountName` value `steventdevne01` is incorrect. Tracing through the CDK naming logic:
+
+   - `StorageAccount.__init__` (line 120-122 of `components/orbitcloud_graviton/az_storage/storage_account.py`) calls `self.stack.name_for(resource_type=storage.StorageAccount, workload_name=self.config.name)` with `config.name = "event"`
+   - `name_for` calls `resource_namer` with `workload_name="event"`, `env="dev"`, `location="northeurope"` (from ESC/azure-native config)
+   - Storage account metadata has `prefix: st`, `alphanumeric: true`, `lowercase: true`
+   - `location_abbr("northeurope")` returns `"neu"` (3 characters), confirmed by test assertions in `test/components/orbitcloud_graviton/az_lib/test_resource_naming.py:11` and the naming snapshot at `test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py:897` which shows `stworkloadtestneu01`
+   - With `alphanumeric=true`, each element is `.title()`d and joined with empty separator: `St` + `Event` + `Dev` + `Neu` + `01` = `StEventDevNeu01`
+   - With `lowercase=true`, the final result is `steventdevneu01`
+
+   The config currently says `steventdevne01` (missing the `u` in `neu`). The comment on line 23 also references this wrong value.
+
+   **Fix:** Change `accountName` from `steventdevne01` to `steventdevneu01`, and update the comment on line 23 accordingly.
+
+### Important (Should Fix)
+
+No new important issues.
+
+### Suggestions (Consider)
+
+No new suggestions.
+
+### Praise
+
+- The developer's approach to the fixes was thorough. The removal of the `linked_vnets` self-reference with an explanatory comment about hub VNet auto-linking is exactly the right level of documentation.
+- The `initial_domain_prefix` fix correctly identified the Azure CIAM API expectation and added a concise, helpful comment.
+- The unique project names now accurately reflect each workload variant, which prevents Pulumi backend conflicts and improves discoverability.
+
+## Summary
+
+**Overall assessment: REQUEST CHANGES**
+
+Three of the four issues from review-01 were correctly resolved. The fourth fix (KEDA `accountName` matching the CDK naming output) contains a typo: the location abbreviation for `northeurope` is `neu` (3 characters), not `ne` (2 characters). The config value `steventdevne01` should be `steventdevneu01`.
+
+This is a single character fix in one file. Once corrected, the implementation is ready for approval.
+
+**Estimated effort to address feedback:** Under 5 minutes. One value change and one comment update in `development/09-app-workload-job-event/Pulumi.dev.yaml`.

--- a/docs/requirements/stack-examples/review-03.md
+++ b/docs/requirements/stack-examples/review-03.md
@@ -1,0 +1,39 @@
+# Review 03
+
+> Status: addressed
+> Date: 2026-03-03
+> Reviewer: Code Review Agent
+> Verdict: APPROVE
+
+## Previous Review Status
+
+- [x] Issue from review-02, Critical #1: KEDA `accountName` typo `steventdevne01` (missing `u`) - FIXED. Line 24 of `development/09-app-workload-job-event/Pulumi.dev.yaml` now correctly reads `steventdevneu01`. The comment on line 23 was also updated to reference the correct value.
+
+## New Findings
+
+### Critical (Must Fix)
+
+None.
+
+### Important (Should Fix)
+
+None.
+
+### Suggestions (Consider)
+
+- **[`/Users/on/src/graviton-oss/.claude/worktrees/stack-examples/docs/requirements/stack-examples/SUMMARY.md:66`]** The SUMMARY.md historical note still references the intermediate incorrect value `steventdevne01` in its description of what was changed in a previous iteration. This is a documentation artifact in a requirements tracking file and has no deployment impact, but could be confusing to someone reading the history. Consider updating to `steventdevneu01` for consistency. This is entirely optional.
+
+### Praise
+
+- The fix is precise and correct. Only the one character (`u` in `neu`) was changed and the surrounding comment was updated to match, with no unintended side effects.
+- The grep across the entire working tree confirms that the old incorrect value `steventdevne01` does not appear in any configuration or source file, only in historical review documents. The fix is clean.
+
+## Summary
+
+**Overall assessment: APPROVE**
+
+The single outstanding issue from review-02 has been correctly resolved. The KEDA `accountName` in `development/09-app-workload-job-event/Pulumi.dev.yaml` now reads `steventdevneu01`, which correctly reflects the CDK naming convention: prefix `st` + workload `event` + env `dev` + location abbreviation `neu` (for `northeurope`) + suffix `01`, all lowercased.
+
+No new issues were found. The branch is ready to merge.
+
+**Estimated effort to address feedback:** The one suggestion is optional and would take under 2 minutes if the author wishes to act on it. No action required for merge.

--- a/docs/requirements/stack-examples/task-01-scaffold.md
+++ b/docs/requirements/stack-examples/task-01-scaffold.md
@@ -1,0 +1,15 @@
+# Task 01: Create directory scaffold and shared files
+
+> Status: done
+
+## Goal
+Create the development/ directory structure with pyproject.toml and README.md, plus all 16 example subdirectories.
+
+## Acceptance Criteria
+- [x] development/ directory exists with pyproject.toml
+- [x] development/README.md with usage instructions
+- [x] All 16 subdirectories created (01-tenant through 16-oracledb)
+- [x] Each subdirectory has Pulumi.yaml, Pulumi.dev.yaml, __main__.py
+
+## Notes
+Following the Copier template pattern and customer project conventions.


### PR DESCRIPTION
## Summary

- Add 16 example Pulumi projects under `development/` covering all 14 Graviton CDK stack types
- Includes 3 app workload variants: HTTP, scheduled job, and event-driven job
- Each example has `Pulumi.yaml`, `Pulumi.dev.yaml` (with inline comments), and `__main__.py` (with debug support)
- Shared `pyproject.toml` and `README.md` with prerequisites and deployment order
- All values use placeholders (RFC 5737 IPs, zero/one UUIDs, example domains) — no real customer data

## Stacks covered

| # | Directory | Stack Type |
|---|-----------|-----------|
| 01 | `01-tenant` | Azure Tenant |
| 02 | `02-environment` | Azure Environment (Pulumi ESC) |
| 03 | `03-landing-zone` | Landing Zone |
| 04 | `04-networking` | Hub-Spoke Network |
| 05 | `05-firewall` | Azure Firewall |
| 06 | `06-app-zone` | Container App Environment |
| 07 | `07-app-workload-http` | HTTP container app |
| 08 | `08-app-workload-job-scheduled` | Cron job |
| 09 | `09-app-workload-job-event` | Queue-triggered job |
| 10 | `10-azuresql` | Azure SQL Server |
| 11 | `11-appservice-suite` | App Service Plan |
| 12 | `12-workload-identities` | Federated credentials |
| 13 | `13-oauth-apps` | OAuth/OIDC apps |
| 14 | `14-entra-external-id` | Entra External ID (B2C) |
| 15 | `15-acme-ssl` | ACME SSL certificates |
| 16 | `16-oracledb` | Oracle DB on Azure VM |

## Test plan

- [ ] Verify all configs parse correctly against base Pydantic models
- [ ] Replace placeholder tenant/subscription IDs and deploy against a test Azure subscription
- [ ] Validate cross-stack `stack://` references resolve after dependent stacks are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)