### PR TITLE
fix(ci): pass bot token via input to action-gh-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,5 +109,4 @@ jobs:
         with:
           body_path: "body.md"
           tag_name: ${{ steps.commitizen.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
+          token: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Fix the 403 "Resource not accessible by integration" error in the Release step
- Pass the GitHub App token via the `token` input instead of `env.GITHUB_TOKEN` so `softprops/action-gh-release` authenticates correctly

## Context
The release step in [run #23709854728](https://github.com/OrbitCloud/graviton-oss/actions/runs/23709854728) failed because the action couldn't create a release. The bot token was passed as an env var instead of the `token` input, which caused the action to use default restricted permissions.

## Test plan
- [ ] Merge and verify the next release workflow run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)