### PR TITLE
feat(datazone): add datazone base orchestrating psql, mysql, sql, storage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.0
+    rev: v4.16.2
     hooks:
       - id: commitizen
   -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/bases/orbitcloud_graviton/datazone/__init__.py
+++ b/bases/orbitcloud_graviton/datazone/__init__.py
@@ -1,0 +1,3 @@
+from .datazone_base import DataZoneBaseConfig, deploy
+
+__all__ = ["DataZoneBaseConfig", "deploy"]

--- a/bases/orbitcloud_graviton/datazone/datazone_base.py
+++ b/bases/orbitcloud_graviton/datazone/datazone_base.py
@@ -1,0 +1,107 @@
+import pulumi
+
+from orbitcloud_graviton.az_lib.types import AzureIdRef
+from orbitcloud_graviton.az_mysql import MysqlFlexibleServer, MysqlFlexibleServerConfig
+from orbitcloud_graviton.az_postgres import PostgresFlexibleServer, PostgresFlexibleServerConfig
+from orbitcloud_graviton.az_sql import (
+    SqlDatabase,
+    SqlDatabaseConfig,
+    SqlServer,
+    SqlServerConfig,
+)
+from orbitcloud_graviton.az_storage import StorageAccount, StorageAccountConfig
+from orbitcloud_graviton.pulumi_lib import (
+    AzureStack,
+    PulumiConfig,
+    generate_stack_schema,
+    get_azure_stack,
+)
+from orbitcloud_graviton.pulumi_lib.azure_base import EntraStack, get_entra_stack
+
+
+class DataZoneBaseConfig(PulumiConfig):
+    log_workspace_id: AzureIdRef | None = None
+
+    postgres: PostgresFlexibleServerConfig | None = None
+    mysql: MysqlFlexibleServerConfig | None = None
+    sql_server: SqlServerConfig | None = None
+    sql_databases: list[SqlDatabaseConfig] | None = None
+    storage_accounts: list[StorageAccountConfig] | None = None
+
+
+def deploy() -> None:
+    generate_stack_schema(model=DataZoneBaseConfig, output_file=".stack_schema.json")
+    config: DataZoneBaseConfig = DataZoneBaseConfig.model_validate({})
+
+    stack: AzureStack = get_azure_stack()
+    entra_config: EntraStack = get_entra_stack()
+
+    opts = pulumi.ResourceOptions(parent=stack.resource_group)
+
+    ##########################################
+    # PostgreSQL Flexible Server
+    ##########################################
+    if config.postgres:
+        psql_config = (
+            config.postgres.model_copy(update={"log_workspace_id": config.log_workspace_id})
+            if config.log_workspace_id
+            else config.postgres
+        )
+        PostgresFlexibleServer(
+            stack=stack,
+            entra_config=entra_config,
+            config=psql_config,
+            opts=opts,
+        )
+
+    ##########################################
+    # MySQL Flexible Server
+    ##########################################
+    if config.mysql:
+        mysql_config = (
+            config.mysql.model_copy(update={"log_workspace_id": config.log_workspace_id})
+            if config.log_workspace_id
+            else config.mysql
+        )
+        MysqlFlexibleServer(
+            stack=stack,
+            entra_config=entra_config,
+            config=mysql_config,
+            opts=opts,
+        )
+
+    ##########################################
+    # Azure SQL Server + Databases
+    ##########################################
+    if config.sql_server:
+        sql_config = (
+            config.sql_server.model_copy(update={"log_workspace_id": config.log_workspace_id})
+            if config.log_workspace_id
+            else config.sql_server
+        )
+        sql_server = SqlServer(stack=stack, config=sql_config, opts=opts)
+
+        for database in config.sql_databases or []:
+            update_kwargs: dict = {}
+            if sql_server.elastic_pool:
+                update_kwargs["elastic_pool_id"] = sql_server.elastic_pool.id
+            if config.log_workspace_id:
+                update_kwargs["log_workspace_id"] = config.log_workspace_id
+
+            SqlDatabase(
+                stack=stack,
+                config=database.model_copy(update=update_kwargs) if update_kwargs else database,
+                server_name=sql_server.server.name,
+                opts=opts,
+            )
+
+    ##########################################
+    # Storage Accounts
+    ##########################################
+    for st in config.storage_accounts or []:
+        st_config = (
+            st.model_copy(update={"log_workspace_id": config.log_workspace_id})
+            if config.log_workspace_id
+            else st
+        )
+        StorageAccount(stack=stack, config=st_config, opts=opts)

--- a/components/orbitcloud_graviton/az_lib/metadata/services/dbformysql.yaml
+++ b/components/orbitcloud_graviton/az_lib/metadata/services/dbformysql.yaml
@@ -1,0 +1,17 @@
+azure_namespace: Microsoft.DBforMySQL
+resources:
+  Server:
+    naming:
+      prefix: mysql
+  AzureADAdministrator:
+    naming:
+      prefix: mysql-admin
+  Configuration:
+    naming:
+      prefix: mysql-conf
+  Database:
+    naming:
+      prefix: mysql-db
+  FirewallRule:
+    naming:
+      prefix: mysql-fw

--- a/components/orbitcloud_graviton/az_mysql/__init__.py
+++ b/components/orbitcloud_graviton/az_mysql/__init__.py
@@ -1,0 +1,27 @@
+from .flexibleserver import (
+    MysqlAuthConfig,
+    MysqlBackupConfig,
+    MysqlCreateMode,
+    MysqlDatabaseConfig,
+    MysqlFlexibleServer,
+    MysqlFlexibleServerConfig,
+    MysqlHAConfig,
+    MysqlMaintenanceConfig,
+    MysqlNetworkConfig,
+    MysqlSku,
+    MysqlStorageConfig,
+)
+
+__all__: list[str] = [
+    "MysqlAuthConfig",
+    "MysqlBackupConfig",
+    "MysqlCreateMode",
+    "MysqlDatabaseConfig",
+    "MysqlFlexibleServer",
+    "MysqlFlexibleServerConfig",
+    "MysqlHAConfig",
+    "MysqlMaintenanceConfig",
+    "MysqlNetworkConfig",
+    "MysqlSku",
+    "MysqlStorageConfig",
+]

--- a/components/orbitcloud_graviton/az_mysql/flexibleserver.py
+++ b/components/orbitcloud_graviton/az_mysql/flexibleserver.py
@@ -1,0 +1,410 @@
+import logging
+
+import pulumi
+from pulumi_azure_native import dbformysql as mysql
+from pulumi_azure_native import monitor
+from pulumi_random import RandomPassword, RandomPasswordArgs
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from orbitcloud_graviton.az_lib.helpers import fmt_name
+from orbitcloud_graviton.az_lib.types import AzureIdRef
+from orbitcloud_graviton.az_monitor import diagnostic_setting
+from orbitcloud_graviton.az_network.types import PublicIpv4FirewallRule
+from orbitcloud_graviton.pulumi_lib import AzureStack, EntraStack
+
+logger = logging.getLogger(__name__)
+
+
+class MysqlAuthConfig(BaseModel):
+    admin_username: str = "cloudsa"
+    admin_password: str | None = None
+
+    entra_auth: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MysqlNetworkConfig(BaseModel):
+    subnet_id: AzureIdRef
+    private_dns_zone_id: AzureIdRef
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlStorageConfig(BaseModel):
+    storage_size_gb: int = Field(default=32, ge=20, le=16384)
+    auto_grow: mysql.EnableStatusEnum = mysql.EnableStatusEnum.DISABLED
+    auto_io_scaling: mysql.EnableStatusEnum = mysql.EnableStatusEnum.ENABLED
+    iops: int | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlBackupConfig(BaseModel):
+    geo_redundant: mysql.EnableStatusEnum = mysql.EnableStatusEnum.DISABLED
+    retention_days: int = 7
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlSku(BaseModel):
+    name: str = "Standard_B1ms"
+    tier: mysql.ServerSkuTier = mysql.ServerSkuTier.BURSTABLE
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlHAConfig(BaseModel):
+    mode: mysql.HighAvailabilityMode = mysql.HighAvailabilityMode.DISABLED
+    standby_availability_zone: str | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlMaintenanceConfig(BaseModel):
+    day_of_week: int = Field(default=0, ge=0, le=6)
+    start_hour: int = Field(default=0, ge=0, le=23)
+    start_minute: int = Field(default=0, ge=0, le=59)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MysqlCreateMode(BaseModel):
+    mode: mysql.CreateMode | None = None
+    source_server_id: AzureIdRef | None = None
+    restore_point_in_time: str | None = None
+
+    @model_validator(mode="after")
+    def validate_create_mode(self) -> "MysqlCreateMode":
+        requires_source = (
+            mysql.CreateMode.POINT_IN_TIME_RESTORE,
+            mysql.CreateMode.GEO_RESTORE,
+            mysql.CreateMode.REPLICA,
+        )
+        if self.mode in requires_source and not self.source_server_id:
+            raise ValueError(f"source_server_id is required when mode is {self.mode}")
+
+        if self.mode == mysql.CreateMode.POINT_IN_TIME_RESTORE and not self.restore_point_in_time:
+            raise ValueError("restore_point_in_time is required when mode is POINT_IN_TIME_RESTORE")
+
+        return self
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlDatabaseConfig(BaseModel):
+    name: str
+    charset: str = "utf8mb4"
+    collation: str = "utf8mb4_unicode_ci"
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MysqlFlexibleServerConfig(BaseModel):
+    server_name: str | None = None
+    server_version: str = "8.4"
+    authentication: MysqlAuthConfig = MysqlAuthConfig()
+    network: MysqlNetworkConfig | None = None
+    sku: MysqlSku = MysqlSku()
+    storage: MysqlStorageConfig = MysqlStorageConfig()
+    backups: MysqlBackupConfig = MysqlBackupConfig()
+    high_availability: MysqlHAConfig = MysqlHAConfig()
+    maintenance: MysqlMaintenanceConfig | None = None
+    create_mode: MysqlCreateMode = MysqlCreateMode()
+    zone: str | None = None
+
+    databases: list[MysqlDatabaseConfig] | None = None
+    server_params: dict[str, str] | None = None
+
+    allowed_public_networks: list[PublicIpv4FirewallRule] | None = None
+    allow_azure_services: bool = False
+
+    log_workspace_id: AzureIdRef | None = None
+
+    @model_validator(mode="after")
+    def validate_network_firewall_exclusive(
+        self,
+    ) -> "MysqlFlexibleServerConfig":
+        if self.network and (self.allowed_public_networks or self.allow_azure_services):
+            raise ValueError(
+                "VNet integration (network) and firewall rules "
+                "(allowed_public_networks / allow_azure_services) are mutually exclusive"
+            )
+        return self
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+
+class MysqlFlexibleServer(pulumi.ComponentResource):
+    def __init__(
+        self,
+        stack: AzureStack,
+        entra_config: EntraStack,
+        config: MysqlFlexibleServerConfig,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        self.stack: AzureStack = stack
+        self.config: MysqlFlexibleServerConfig = config
+        self.entra_config: EntraStack = entra_config
+
+        super().__init__(
+            "Graviton:MysqlFlexibleServer",
+            name=f"mysql-{stack.workload_name}-{stack.env}",
+            props=None,
+            opts=opts,
+        )
+
+        self._opts: pulumi.ResourceOptions = pulumi.ResourceOptions.merge(
+            opts1=opts, opts2=pulumi.ResourceOptions(parent=self)
+        )
+        self.admin_password: str | pulumi.Output[str] = (
+            self.config.authentication.admin_password or self._random_admin_password().result
+        )
+
+        self.server: mysql.Server = self._server()
+        self.admins = self._server_admin()
+        self.databases: list[mysql.Database] = self._databases()
+        self.firewall_rules: list[mysql.FirewallRule] = self._firewall_rules()
+        self.azure_services_rule: mysql.FirewallRule | None = self._allow_azure_services()
+        self._diagnostic_settings()
+        self.server_params: list[mysql.Configuration] | None = self._server_params()
+
+        self._outputs()
+
+    def _server(self) -> mysql.Server:
+        public_access = mysql.EnableStatusEnum.DISABLED
+        if not self.config.network:
+            public_access = mysql.EnableStatusEnum.ENABLED
+
+        args = mysql.ServerArgs(
+            resource_group_name=self.stack.resource_group.name,
+            server_name=self.config.server_name or self.stack.name_for(resource_type=mysql.Server),
+            location=self.stack.location,
+            # SKU
+            sku=mysql.MySQLServerSkuArgs(
+                name=self.config.sku.name,
+                tier=self.config.sku.tier,
+            ),
+            high_availability=mysql.HighAvailabilityArgs(
+                mode=self.config.high_availability.mode,
+                standby_availability_zone=self.config.high_availability.standby_availability_zone,
+            ),
+            version=self.config.server_version,
+            # Storage
+            availability_zone=self.config.zone,
+            storage=mysql.StorageArgs(
+                auto_grow=self.config.storage.auto_grow,
+                auto_io_scaling=self.config.storage.auto_io_scaling,
+                storage_size_gb=self.config.storage.storage_size_gb,
+                iops=self.config.storage.iops,
+            ),
+            # Authentication
+            administrator_login=self.config.authentication.admin_username,
+            administrator_login_password=self.admin_password,
+            # Networking
+            network=mysql.NetworkArgs(
+                delegated_subnet_resource_id=self.config.network.subnet_id
+                if self.config.network
+                else None,
+                private_dns_zone_resource_id=self.config.network.private_dns_zone_id
+                if self.config.network
+                else None,
+                public_network_access=public_access,
+            ),
+            # Backups
+            backup=mysql.BackupArgs(
+                geo_redundant_backup=self.config.backups.geo_redundant,
+                backup_retention_days=self.config.backups.retention_days,
+            ),
+            maintenance_window=mysql.MaintenanceWindowArgs(
+                custom_window="Enabled",
+                day_of_week=self.config.maintenance.day_of_week,
+                start_hour=self.config.maintenance.start_hour,
+                start_minute=self.config.maintenance.start_minute,
+            )
+            if self.config.maintenance
+            else None,
+            # Create mode
+            create_mode=self.config.create_mode.mode,
+            source_server_resource_id=self.config.create_mode.source_server_id,
+            restore_point_in_time=self.config.create_mode.restore_point_in_time,
+            data_encryption=mysql.DataEncryptionArgs(
+                type=mysql.DataEncryptionType.SYSTEM_MANAGED,
+            ),
+            replication_role=mysql.ReplicationRole.NONE,
+        )
+
+        return mysql.Server(
+            resource_name=self.stack.name_for(resource_type=mysql.Server),
+            args=args,
+            opts=self._opts,
+        )
+
+    def _random_admin_password(self) -> RandomPassword:
+        return RandomPassword(
+            resource_name=self.stack.name_for(
+                resource_type=RandomPassword,
+                workload_name=f"{self.stack.workload_name}-mysql-admin-pwd",
+            ),
+            args=RandomPasswordArgs(
+                length=24,
+                special=True,
+                upper=True,
+                lower=True,
+                numeric=True,
+            ),
+            opts=self._opts,
+        )
+
+    def _server_admin(self) -> mysql.AzureADAdministrator | None:
+        if not self.config.authentication.entra_auth:
+            return None
+
+        if self.stack.azure_environment:
+            return mysql.AzureADAdministrator(
+                resource_name=self.stack.name_for(
+                    resource_type=mysql.AzureADAdministrator,
+                    workload_name=self.stack.azure_environment.pulumi_esc_app.name,
+                ),
+                args=mysql.AzureADAdministratorArgs(
+                    resource_group_name=self.stack.resource_group.name,
+                    server_name=self.server.name,
+                    tenant_id=str(self.entra_config.tenant_id),
+                    administrator_type=mysql.AdministratorType.ACTIVE_DIRECTORY,
+                    sid=str(
+                        self.stack.azure_environment.pulumi_esc_app.service_principal_object_id
+                    ),
+                    login=self.stack.azure_environment.pulumi_esc_app.name,
+                    identity_resource_id=None,
+                ),
+                opts=pulumi.ResourceOptions(parent=self.server),
+            )
+
+        logger.warning(
+            "Entra authentication is enabled but azure_environment is not set. "
+            "No Entra admin will be configured for the MySQL server."
+        )
+        return None
+
+    def _databases(self) -> list[mysql.Database]:
+        if not self.config.databases:
+            return []
+
+        return [
+            mysql.Database(
+                resource_name=self.stack.name_for(
+                    resource_type=mysql.Database, workload_name=db.name
+                ),
+                args=mysql.DatabaseArgs(
+                    resource_group_name=self.stack.resource_group.name,
+                    server_name=self.server.name,
+                    database_name=db.name,
+                    charset=db.charset,
+                    collation=db.collation,
+                ),
+                opts=pulumi.ResourceOptions(parent=self.server),
+            )
+            for db in self.config.databases
+        ]
+
+    def _firewall_rules(self) -> list[mysql.FirewallRule]:
+        if not self.config.allowed_public_networks:
+            return []
+
+        return [
+            mysql.FirewallRule(
+                resource_name=self.stack.name_for(
+                    resource_type=mysql.FirewallRule, workload_name=fmt_name(rule.name)
+                ),
+                args=mysql.FirewallRuleArgs(
+                    firewall_rule_name=rule.name,
+                    server_name=self.server.name,
+                    resource_group_name=self.stack.resource_group.name,
+                    start_ip_address=rule.first_ip,
+                    end_ip_address=rule.last_ip,
+                ),
+                opts=pulumi.ResourceOptions.merge(
+                    opts1=self._opts,
+                    opts2=pulumi.ResourceOptions(parent=self.server, delete_before_replace=True),
+                ),
+            )
+            for rule in self.config.allowed_public_networks
+        ]
+
+    def _allow_azure_services(self) -> mysql.FirewallRule | None:
+        if not self.config.allow_azure_services:
+            return None
+
+        return mysql.FirewallRule(
+            resource_name=self.stack.name_for(
+                resource_type=mysql.FirewallRule, workload_name="AzureServices"
+            ),
+            args=mysql.FirewallRuleArgs(
+                firewall_rule_name="AzureServices",
+                server_name=self.server.name,
+                resource_group_name=self.stack.resource_group.name,
+                start_ip_address="0.0.0.0",
+                end_ip_address="0.0.0.0",
+            ),
+            opts=pulumi.ResourceOptions.merge(
+                opts1=self._opts,
+                opts2=pulumi.ResourceOptions(parent=self.server, delete_before_replace=True),
+            ),
+        )
+
+    def _server_params(self) -> list[mysql.Configuration] | None:
+        if not self.config.server_params:
+            return None
+
+        return [
+            mysql.Configuration(
+                resource_name=self.stack.name_for(
+                    mysql.Configuration,
+                    workload_name=k.replace("_", "-").replace(".", "-"),
+                ),
+                args=mysql.ConfigurationArgs(
+                    resource_group_name=self.stack.resource_group.name,
+                    server_name=self.server.name,
+                    source="user-override",
+                    configuration_name=k,
+                    value=v,
+                ),
+                opts=pulumi.ResourceOptions(parent=self.server),
+            )
+            for k, v in self.config.server_params.items()
+        ]
+
+    def _diagnostic_settings(self) -> monitor.DiagnosticSetting | None:
+        if self.config.log_workspace_id:
+            return diagnostic_setting(
+                resource=self.server,
+                log_workspace_id=self.config.log_workspace_id,
+                metric_categories=[
+                    "AllMetrics",
+                ],
+                log_categories=[
+                    "MySqlAuditLogs",
+                    "MySqlSlowLogs",
+                ],
+                opts=pulumi.ResourceOptions(parent=self.server),
+            )
+        return None
+
+    def _outputs(self) -> None:
+        self.register_outputs(
+            outputs={"server": self.server},
+        )
+
+        self.stack.export(
+            exports={
+                "mysql": {
+                    "id": self.server.id,
+                    "name": self.server.name,
+                    "endpoint": self.server.fully_qualified_domain_name,
+                    "admin": {
+                        "username": self.config.authentication.admin_username,
+                        "password": self.admin_password,
+                    },
+                }
+            }
+        )

--- a/docs/requirements/mysql-flexible-server/README.md
+++ b/docs/requirements/mysql-flexible-server/README.md
@@ -1,0 +1,179 @@
+# MySQL Flexible Server Component Requirements
+
+## Overview
+
+New Graviton CDK component for provisioning Azure Database for MySQL Flexible Server. Follows the established PostgreSQL Flexible Server pattern (`az_postgres`) with additions for firewall rules (from `az_sql` pattern) and MySQL-specific database resources.
+
+Default posture: private VNet integration, system-assigned identity, Entra authentication enabled, MySQL 8.4.
+
+## Goals
+
+- Provide a reusable, opinionated MySQL Flexible Server component consistent with existing Graviton patterns
+- Default to secure-by-default networking (VNet integration, public access disabled)
+- Support Entra ID authentication with system-assigned managed identity
+- Allow optional IP allowlisting for hybrid scenarios
+- Support creating databases on the server
+
+## User Stories
+
+- As a platform engineer, I want to deploy a MySQL Flexible Server into my landing zone VNet so that database traffic stays private.
+- As a platform engineer, I want Entra authentication enabled by default so that I can use managed identities for access.
+- As a platform engineer, I want to create databases on the server so that application teams have their schemas ready.
+- As a platform engineer, I want to optionally allowlist public IPs so that I can support hybrid connectivity scenarios.
+
+## Functional Requirements
+
+### Must Have (P0)
+
+- [ ] **Server resource** — `MysqlFlexibleServer` ComponentResource creating `dbformysql.Server`
+  - Default version: `"8.4"` (passed as string; SDK enum lags behind Azure API)
+  - Default SKU: `Standard_B1ms` / `Burstable` tier
+  - System-assigned identity via `identity` arg (note: MySQL SDK uses `ManagedServiceIdentityType.USER_ASSIGNED` enum but system-assigned is set differently — verify at implementation)
+  - Data encryption: system-managed
+  - Replication role: `None` (standalone)
+  - Create mode: `Default` (with support for `PointInTimeRestore`, `GeoRestore`, `Replica`)
+
+- [ ] **Entra authentication** — `dbformysql.AzureAdAdministrator` resource
+  - Enabled by default
+  - Registers the Pulumi ESC app service principal as admin (matching PostgreSQL pattern)
+  - Config option to supply additional Entra admin object IDs
+
+- [ ] **Authentication config** — `MysqlAuthConfig` model
+  - `admin_username: str = "cloudsa"`
+  - `admin_password: str | None = None` (auto-generated via `random.RandomPassword` if not provided)
+  - `entra_auth: bool = True`
+  - `mysql_auth: bool = True` (native MySQL password auth toggle)
+
+- [ ] **Networking** — `MysqlNetworkConfig` model
+  - `subnet_id: AzureIdRef` — delegated subnet (`Microsoft.DBforMySQL/flexibleServers`)
+  - `private_dns_zone_id: AzureIdRef` — private DNS zone for name resolution
+  - Public network access: `Disabled` by default when VNet config is provided
+  - Note: MySQL SDK uses `private_dns_zone_resource_id` (differs from PostgreSQL's `private_dns_zone_arm_resource_id`)
+
+- [ ] **Firewall rules** — IP allowlisting (from `az_sql` pattern)
+  - `allowed_public_networks: list[PublicIpv4FirewallRule] | None = None`
+  - `allow_azure_services: bool = False`
+  - Reuse `PublicIpv4FirewallRule` from `orbitcloud_graviton.az_network.types`
+  - Public network access set to `Enabled` when firewall rules are configured
+  - Validation: firewall rules and VNet integration are mutually exclusive
+
+- [ ] **Database resources** — `MysqlDatabaseConfig` model + creation
+  - `name: str`
+  - `charset: str = "utf8mb4"`
+  - `collation: str = "utf8mb4_unicode_ci"`
+  - Config field: `databases: list[MysqlDatabaseConfig] | None = None`
+  - Creates `dbformysql.Database` resources parented to the server
+
+- [ ] **Storage config** — `MysqlStorageConfig` model
+  - `storage_size_gb: int = 32`
+  - `auto_grow: EnableStatusEnum = DISABLED`
+  - `auto_io_scaling: EnableStatusEnum = ENABLED`
+  - `iops: int | None = None`
+
+- [ ] **Backup config** — `MysqlBackupConfig` model
+  - `geo_redundant: EnableStatusEnum = DISABLED`
+  - `retention_days: int = 7`
+
+- [ ] **Server parameters** — `server_params: dict[str, str] | None = None`
+  - Creates `dbformysql.Configuration` resources per parameter
+  - Source: `user-override`
+
+- [ ] **Diagnostic settings** — conditional, using shared `diagnostic_setting()` helper
+  - Log categories: MySQL-appropriate categories (e.g., `MySqlAuditLogs`, `MySqlSlowLogs`)
+  - Metric category: `AllMetrics`
+
+- [ ] **Stack outputs** — export server id, name, FQDN, admin credentials
+
+### Should Have (P1)
+
+- [ ] **High Availability** — `MysqlHAConfig` model
+  - `mode: HighAvailabilityMode = DISABLED`
+  - `standby_availability_zone: str | None = None`
+  - Support `ZoneRedundant` and `SameZone` modes
+
+- [ ] **Maintenance window** — `MysqlMaintenanceConfig` model
+  - `day_of_week: int = 0`
+  - `start_hour: int = 0`
+  - `start_minute: int = 0`
+
+- [ ] **SKU config** — `MysqlSku` model
+  - `name: str = "Standard_B1ms"`
+  - `tier: ServerSkuTier = BURSTABLE`
+
+### Nice to Have (P2)
+
+- [ ] **Create mode support** — `MysqlCreateMode` model
+  - `mode: CreateMode = DEFAULT`
+  - `source_server_id: str | None = None` (required for restore/replica)
+  - `restore_point_in_time: str | None = None` (required for PITR)
+  - Cross-field validation via `model_validator`
+
+## Non-Functional Requirements
+
+- **Naming**: Use `stack.name_for()` with prefixes from `dbformysql.yaml` metadata
+- **Config validation**: Pydantic `BaseModel` with `extra="forbid"`, `arbitrary_types_allowed=True`
+- **Security**: No secrets in plain text; admin password auto-generated if not supplied
+- **Backwards Compatibility**: N/A — new component, no existing users
+- **Testing**: Unit tests using `pulumi_mocks` following existing test patterns
+
+## Edge Cases & Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| VNet config + firewall rules both provided | Pydantic validation error — mutually exclusive |
+| Firewall rules without VNet config | Public access enabled, rules created |
+| No VNet config and no firewall rules | Public access enabled, no rules (open — user's choice) |
+| No admin password provided | Auto-generate via `random.RandomPassword` |
+| Entra auth disabled | Skip `AzureAdAdministrator` resource creation |
+| Empty databases list | No `Database` resources created |
+| HA mode set but Burstable SKU | Azure API will reject — document this constraint, no client-side validation |
+| SDK lacks 8.4 enum | Pass `"8.4"` as string directly to `version` arg |
+
+## Affected Components/Bases
+
+### New (create)
+- `components/orbitcloud_graviton/az_mysql/__init__.py`
+- `components/orbitcloud_graviton/az_mysql/flexibleserver.py`
+- `components/orbitcloud_graviton/az_lib/metadata/services/dbformysql.yaml`
+- `test/components/orbitcloud_graviton/az_mysql/__init__.py`
+- `test/components/orbitcloud_graviton/az_mysql/test_flexibleserver.py`
+
+### Modified
+- `pyproject.toml` — add `az_mysql` package entry
+
+## Out of Scope
+
+- Read replicas (cross-region or same-region)
+- Customer-managed encryption keys (BYOK)
+- Deployable base stack (`bases/` entry point) — can be added later
+- Private Endpoint connectivity (component uses VNet injection; PE can be composed externally)
+- Slow query log configuration beyond server params
+- MySQL Single Server (legacy, deprecated)
+
+## Dependencies
+
+- `pulumi_azure_native.dbformysql` (v3.14.0+ installed)
+- `pulumi_random` — for `RandomPassword`
+- `orbitcloud_graviton.az_network.types.PublicIpv4FirewallRule`
+- `orbitcloud_graviton.az_lib` — naming, metadata loader
+- `orbitcloud_graviton.pulumi_lib` — `AzureStack`, `EntraStack`
+- `orbitcloud_graviton.az_monitor` — `diagnostic_setting()` helper
+
+## Open Questions
+
+- [x] MySQL 8.4 not in SDK enum → pass as raw string ✓
+- [ ] Confirm MySQL diagnostic log category names against Azure API docs
+- [ ] Verify system-assigned identity support — MySQL SDK exposes `ManagedServiceIdentityType.USER_ASSIGNED` only; system-assigned may need to be set via a different mechanism or may not be supported for MySQL Flexible Server (fallback: user-assigned identity)
+
+## Acceptance Criteria
+
+- `MysqlFlexibleServer` component deploys a MySQL 8.4 Flexible Server with VNet integration
+- Entra authentication is enabled by default with ESC app as admin
+- Admin password is auto-generated when not provided
+- Databases can be created on the server
+- Firewall rules work when VNet integration is not used
+- Validation prevents combining VNet integration with firewall rules
+- All config models enforce `extra="forbid"`
+- YAML metadata enables correct naming via `stack.name_for()`
+- `pyproject.toml` includes the new package
+- Unit tests pass covering config validation and resource creation

--- a/docs/requirements/mysql-flexible-server/review-01.md
+++ b/docs/requirements/mysql-flexible-server/review-01.md
@@ -1,0 +1,78 @@
+# Review 01
+
+> Status: addressed
+> Date: 2026-02-28
+> Reviewer: Code Review Agent
+> Verdict: REQUEST CHANGES
+
+## Previous Review Status
+
+No previous reviews.
+
+## New Findings
+
+### Critical (Must Fix)
+
+- **[flexibleserver.py:19] `mysql_auth` field is declared but never used in the component.**
+  The `MysqlAuthConfig.mysql_auth` field (which toggles native MySQL password authentication) is never referenced when constructing the `mysql.Server` resource. Looking at the Azure SDK, the MySQL Flexible Server API does not expose an `auth_config` arg like PostgreSQL does (PostgreSQL has `AuthConfigArgs` with `active_directory_auth` and `password_auth`). If the MySQL API does not support toggling password auth independently, this field should either (a) be removed entirely, or (b) be documented as a no-op / future placeholder. Leaving it as-is creates a false expectation that setting `mysql_auth=False` would disable password authentication on the server. Either way, the requirement says `mysql_auth: bool = True` should be a "native MySQL password auth toggle" -- but if the toggle does nothing, that is misleading.
+
+- **[flexibleserver.py:256-279] `_server_admin` silently returns None when `azure_environment` is not set, even when `entra_auth=True`.**
+  When `entra_auth=True` (the default) but `stack.azure_environment` is `None`, the method returns `None` without creating an Entra admin or raising a warning. This means a user who leaves `entra_auth=True` (the default) in a stack without an `azure_environment` gets no Entra admin configured and no indication that something is missing. The PostgreSQL component has the same pattern, so this is technically consistent, but the requirement says "Enabled by default / Registers the Pulumi ESC app service principal as admin." Consider at minimum logging a warning when `entra_auth=True` but no `azure_environment` is available, so users are not silently left without Entra authentication despite expecting it.
+
+### Important (Should Fix)
+
+- **[test_mysql_config.py] No Pulumi resource-creation tests -- only config model validation is tested.**
+  The 43 tests exclusively cover Pydantic model defaults, validation, and `extra="forbid"` enforcement. There are zero tests that instantiate `MysqlFlexibleServer` with Pulumi mocks to verify that the correct Azure resources are created with the expected properties. For comparison, the requirements explicitly state: "Unit tests pass covering config validation **and resource creation**." Key behaviors that are untested:
+  - Auto-generated admin password (RandomPassword creation)
+  - Entra admin resource created when `entra_auth=True`
+  - Database resources created from `databases` list
+  - Firewall rules created from `allowed_public_networks`
+  - Server params created from `server_params`
+  - Diagnostic settings created when `log_workspace_id` is provided
+  - Public network access toggled based on VNet config presence
+
+  The PostgreSQL component also lacks resource-creation tests (`test_postgres_config.py` is config-only), so this is consistent with the existing codebase pattern. However, the requirements for this feature explicitly call for resource creation coverage. I am marking this as "Important" rather than "Critical" since the codebase pattern is config-only tests, but the developer should be aware this is a gap.
+
+- **[flexibleserver.py:125] Mutual exclusion validation triggers on `allowed_public_networks=[]` (empty list).**
+  The validator uses `m.allowed_public_networks is not None` to detect firewall rules. An empty list `[]` passes this check, causing validation to fail if VNet config is also provided. While this is defensive, it means a user cannot explicitly pass an empty list to indicate "no firewall rules." Consider changing to `if m.network and (m.allowed_public_networks or m.allow_azure_services):` so that an empty list is treated as "no rules" -- which is arguably the more intuitive behavior. The default is `None` so this only affects explicit empty-list usage.
+
+- **[flexibleserver.py:75] `validate_create_mode` uses positional `m` instead of `self`/`cls` convention.**
+  Pydantic v2 `@model_validator(mode="after")` methods should use `self` as the first parameter name (since the validator receives an instance of the model). Using `m` is not incorrect, but it deviates from Pydantic v2 documentation conventions and from the style used in other files (e.g., `az_postgres` also uses `m`, so this is consistent within the project, but the Pydantic docs recommend `self`). Same applies to line 122 (`validate_network_firewall_exclusive`). This is a minor consistency point -- follow whatever the project chooses, but be aware the Pydantic docs use `self`.
+
+### Suggestions (Consider)
+
+- **[flexibleserver.py:157-159] Admin password type annotation could be more precise.**
+  The type `str | pulumi.Output[str]` is correct but consider extracting a type alias (e.g., `SecretValue = str | pulumi.Output[str]`) since the PostgreSQL component uses the same pattern. This would reduce duplication and make the intent clearer. Not blocking since PostgreSQL does the same inline annotation.
+
+- **[flexibleserver.py:100-132] Consider adding a `__all__` or docstrings to `MysqlFlexibleServerConfig`.**
+  The top-level config class has many fields. A brief docstring listing the major sections (auth, network, storage, etc.) would help users discover the available options without reading the full source. This is a readability improvement, not a requirement.
+
+- **[dbformysql.yaml] Consider adding `azure_namespace` documentation comment.**
+  The YAML file uses `azure_namespace: Microsoft.DBforMySQL` but there is no comment explaining the resource type mapping. Other YAML files in the metadata directory may or may not have this -- it would be helpful for maintainability.
+
+- **[flexibleserver.py:385-402] Password exported in stack outputs.**
+  The admin password (potentially auto-generated) is exported as a stack output. While this matches the PostgreSQL pattern and is necessary for operational use, ensure that `pulumi.Output.secret()` wrapping is handled by the `stack.export` method or the RandomPassword resource's `result` property already being marked as secret. If `stack.export` does not automatically mark values as secret, the password could appear in plaintext in `pulumi stack output`. This is a security consideration worth verifying.
+
+### Praise
+
+- Clean, consistent adaptation of the PostgreSQL pattern to MySQL. The developer clearly studied the existing `az_postgres` component and adapted it thoughtfully, accounting for MySQL-specific differences (SDK enum names, `private_dns_zone_resource_id`, `AzureADAdministrator` vs `Administrator`, `DataEncryptionType.SYSTEM_MANAGED` vs `SYSTEM_ASSIGNED`).
+- Excellent Pydantic model design. The config models are well-structured with appropriate defaults, field validation (`ge`/`le` bounds on storage and maintenance fields), and `extra="forbid"` on every model.
+- Good cross-field validation. The `MysqlCreateMode` validator correctly requires `source_server_id` for restore/replica modes and `restore_point_in_time` specifically for PITR. The VNet/firewall mutual exclusion is also well-implemented.
+- Thorough coverage of `extra="forbid"` in tests. Every config model has a dedicated test ensuring extra fields are rejected.
+- YAML metadata file is clean and correctly maps all five MySQL resource types with sensible prefixes.
+- The `__init__.py` re-exports are complete and match the `__all__` list.
+- `pyproject.toml` and metadata snapshot test updates are correct and alphabetically ordered.
+
+## Summary
+
+Overall this is a solid implementation that closely follows the established PostgreSQL pattern while correctly adapting to MySQL SDK differences. The code is clean, well-structured, and the config validation is thorough.
+
+**Key concerns:**
+
+1. The `mysql_auth` field is defined but never used in resource creation -- this creates a misleading API surface where users think they can toggle MySQL native auth, but the setting has no effect.
+2. The `_server_admin` method silently does nothing when `azure_environment` is missing, which could surprise users who expect Entra auth to be configured by default.
+3. No resource-creation tests exist. While this is consistent with the PostgreSQL component's test approach, the requirements explicitly call for resource creation test coverage.
+
+**Verdict: REQUEST CHANGES** -- primarily due to the unused `mysql_auth` field creating a misleading API. The test gap is important but follows existing codebase patterns. The `_server_admin` silent fallback should at minimum be documented or warned about.
+
+**Estimated effort to address:** 1-2 hours (remove or document `mysql_auth`, add a warning log for missing `azure_environment`, optionally add resource-creation tests).

--- a/docs/requirements/mysql-flexible-server/review-02.md
+++ b/docs/requirements/mysql-flexible-server/review-02.md
@@ -1,0 +1,75 @@
+# Review 02
+
+> Status: pending-dev
+> Date: 2026-02-28
+> Reviewer: Code Review Agent
+> Verdict: APPROVE
+
+## Previous Review Status
+
+All Critical and Important items from review-01 have been addressed:
+
+- [x] **[Critical] `mysql_auth` field declared but never used** - FIXED. The field has been removed from `MysqlAuthConfig`. The model now only contains `admin_username`, `admin_password`, and `entra_auth`. Clean removal with no leftover references.
+
+- [x] **[Critical] `_server_admin` silently returns None when `azure_environment` is not set** - FIXED. Lines 283-286 of `flexibleserver.py` now log a warning via `logger.warning()` when `entra_auth=True` but `azure_environment` is missing. The logger is properly initialized at module level (line 15). Two new tests verify the behavior: `test_warning_logged_when_entra_auth_but_no_azure_environment` and `test_no_warning_when_entra_auth_disabled`.
+
+- [x] **[Important] No Pulumi resource-creation tests** - FIXED. A new `test_mysql_resource.py` file contains 18 tests covering: server creation, auto-generated and explicit passwords, public network access toggle, databases, firewall rules, Azure services rule, server params, Entra admin (with/without `azure_environment`, enabled/disabled), warning log behavior, SKU properties, and server version.
+
+- [x] **[Important] Empty list mutual exclusion validation** - FIXED. Line 128 now uses `m.allowed_public_networks or m.allow_azure_services` (truthiness check) instead of `m.allowed_public_networks is not None`. A dedicated test `test_server_config_vnet_with_empty_firewall_list_allowed` confirms an empty list does not trigger the mutual exclusion error.
+
+## Verification of Fixes
+
+### Fix 1: `mysql_auth` removal
+Traced `MysqlAuthConfig` at line 18-24. The class now has exactly three fields: `admin_username`, `admin_password`, `entra_auth`. No references to `mysql_auth` exist anywhere in the codebase. The config test `test_auth_config_defaults` at `test_mysql_config.py:25-29` confirms only these three fields. Correct.
+
+### Fix 2: Warning log for missing `azure_environment`
+Traced the full path in `_server_admin` (lines 259-287):
+1. If `entra_auth` is `False`, returns `None` immediately (line 260-261). No warning -- correct.
+2. If `azure_environment` is set, creates `AzureADAdministrator` (lines 263-281). No warning -- correct.
+3. Otherwise, logs the warning (lines 283-286) and returns `None`. Correct.
+
+The test at `test_mysql_resource.py:251-262` uses `caplog` to verify the warning message content. The negative test at lines 266-276 confirms no warning when `entra_auth=False`. Both tests pass.
+
+### Fix 3: Resource-creation tests
+All 18 tests in `test_mysql_resource.py` pass. The tests use the project's standard `pulumi_mocks.set_mocks()` pattern and `@pulumi.runtime.test` decorator. The `_make_stack` helper follows the same pattern as other test modules (keyvault, loganalytics). Tests verify both positive cases (resource created) and negative cases (resource not created when config is absent).
+
+### Fix 4: Empty list mutual exclusion
+The validator at line 128 now reads:
+```python
+if m.network and (m.allowed_public_networks or m.allow_azure_services):
+```
+An empty list `[]` is falsy in Python, so `m.allowed_public_networks or m.allow_azure_services` evaluates to `False` when `allowed_public_networks=[]` and `allow_azure_services=False`. The test at `test_mysql_config.py:324-334` confirms this works. Correct.
+
+## New Findings
+
+### Suggestions (Consider)
+
+- **[test_mysql_resource.py] No test for diagnostic settings creation.** The `_diagnostic_settings` method (lines 377-391) is not exercised by any resource test. When `log_workspace_id` is provided, a `monitor.DiagnosticSetting` should be created with MySQL-specific log categories (`MySqlAuditLogs`, `MySqlSlowLogs`). The PostgreSQL component also lacks this test, so this is consistent with the codebase pattern. Not blocking, but would increase confidence that diagnostic settings are wired correctly.
+
+- **[flexibleserver.py:355] `_server_params` returns `None` vs `[]` inconsistency.** When no server params are configured, `_server_params` returns `None`, while `_databases` and `_firewall_rules` return empty lists `[]` in the same scenario. This inconsistency also exists in the PostgreSQL component, so it matches the project pattern. However, a consumer checking `if component.server_params:` behaves identically for both `None` and `[]`, so this is purely an API consistency point. Not blocking.
+
+- **[flexibleserver.py:78, 125] Validator `m` parameter naming.** Carried forward from review-01 as a minor style note. The project consistently uses `m` across both PostgreSQL and MySQL components, so this is an intentional project convention. No action needed.
+
+### Praise
+
+- Clean, targeted fixes. Each review-01 item was addressed precisely without introducing regressions or unnecessary changes.
+- The resource-creation test suite is well-structured. Tests cover both positive and negative cases for every resource type. The Entra admin tests are particularly thorough, testing three distinct scenarios (no `azure_environment`, disabled, and fully configured).
+- The warning log test uses `caplog` correctly with the proper logger name, and the negative test ensures no false warnings.
+- The empty-list fix is the correct Python-idiomatic approach. Using truthiness rather than `is not None` is the right pattern here.
+- The `SUMMARY.md` documentation is thorough and captures all decisions and trade-offs clearly, which will be valuable for future maintainers.
+
+## Test Results
+
+All tests pass:
+- `test_mysql_config.py`: 44 passed (config validation)
+- `test_mysql_resource.py`: 20 passed (resource creation)
+- `test_metadata_snapshot.py`: 381 passed (includes 5 new MySQL resource types)
+- Ruff: All checks passed
+
+## Summary
+
+All Critical and Important items from review-01 have been correctly addressed. The fixes are clean, well-tested, and consistent with the existing codebase patterns. The two remaining suggestions (diagnostic settings test, `None` vs `[]` return type inconsistency) are minor and match the PostgreSQL component's existing patterns.
+
+The implementation is complete: config models are validated, resources are created correctly, the YAML metadata is registered, tests cover both config validation and resource creation, and the code passes linting.
+
+**Verdict: APPROVE** -- ready to merge.

--- a/poetry.lock
+++ b/poetry.lock
@@ -625,14 +625,14 @@ test = ["pytest"]
 
 [[package]]
 name = "commitizen"
-version = "4.16.0"
+version = "4.16.2"
 description = "Python commitizen client tool"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["dev"]
 files = [
-    {file = "commitizen-4.16.0-py3-none-any.whl", hash = "sha256:bf239e8cc528480ea93175d0af96a58a83a2a78f17a5c9505521aa815952bdcd"},
-    {file = "commitizen-4.16.0.tar.gz", hash = "sha256:bcf4f69b918533bed12668a4bada57f493377cae0123163c92d638f5b19c39ca"},
+    {file = "commitizen-4.16.2-py3-none-any.whl", hash = "sha256:12338058fb57026d1a3f15c3a4835d999d447d6591297d9509b99ac93e327a9f"},
+    {file = "commitizen-4.16.2.tar.gz", hash = "sha256:346f32cb81641ec12716f78d16ab7caab28a5e728efc0da36a15a0c6c6839513"},
 ]
 
 [package.dependencies]
@@ -2373,13 +2373,13 @@ files = [
 
 [[package]]
 name = "pulumi"
-version = "3.237.0"
+version = "3.239.0"
 description = "Pulumi's Python SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pulumi-3.237.0-py3-none-any.whl", hash = "sha256:23a1f1e2cca3b1eeaa592b1494826dc7761eb641a559a67394c7698d79928991"},
+    {file = "pulumi-3.239.0-py3-none-any.whl", hash = "sha256:e6959bb25fc11bfbfdf9085be29d81702b3c0033654c6001310a2e0f4549253a"},
 ]
 
 [package.dependencies]
@@ -2434,19 +2434,19 @@ semver = ">=2.8.1"
 
 [[package]]
 name = "pulumi-cloudinit"
-version = "1.4.17"
+version = "1.5.0"
 description = "A Pulumi package for creating and managing cloudinit cloud resources."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pulumi_cloudinit-1.4.17-py3-none-any.whl", hash = "sha256:980193bedaf16fb41eef70ffad3bc22ff4971bf80d4ecca528a58a6f73d3d3eb"},
-    {file = "pulumi_cloudinit-1.4.17.tar.gz", hash = "sha256:fcd0e77c3c5789f095c064b62cbb738098e30e121877163753fe28dd0d154f5d"},
+    {file = "pulumi_cloudinit-1.5.0-py3-none-any.whl", hash = "sha256:c7ced57bd349642d94c3d9314f49aa270b3b737be9bb43d383e4753151f1fc98"},
+    {file = "pulumi_cloudinit-1.5.0.tar.gz", hash = "sha256:06e6aea38ab0f823b11863c2d171fe7ca547329b174aab772d05d573d43cf87e"},
 ]
 
 [package.dependencies]
 parver = ">=0.2.1"
-pulumi = ">=3.165.0,<4.0.0"
+pulumi = ">=3.231.0,<4.0.0"
 semver = ">=2.8.1"
 
 [[package]]
@@ -2485,19 +2485,19 @@ semver = ">=2.8.1"
 
 [[package]]
 name = "pulumi-random"
-version = "4.19.2"
+version = "4.20.0"
 description = "A Pulumi package to safely use randomness in Pulumi programs."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pulumi_random-4.19.2-py3-none-any.whl", hash = "sha256:479f66f82bbb4a0a30d9290e8cf7842805c6291c67ec191fc976203701052e70"},
-    {file = "pulumi_random-4.19.2.tar.gz", hash = "sha256:5735776efa8364e4c2302c89103ab5eb97ca768fce976adf243f555cf04c15ba"},
+    {file = "pulumi_random-4.20.0-py3-none-any.whl", hash = "sha256:f70e1aac14ecc0b48269282ec8deb1dd204aff4b7eef9da70922d5402c8f080d"},
+    {file = "pulumi_random-4.20.0.tar.gz", hash = "sha256:509a66414da50e1aed2f2fc70be0781269ca0aebe2d18a6fd6662e49a7f61621"},
 ]
 
 [package.dependencies]
 parver = ">=0.2.1"
-pulumi = ">=3.165.0,<4.0.0"
+pulumi = ">=3.231.0,<4.0.0"
 semver = ">=2.8.1"
 
 [[package]]
@@ -2519,19 +2519,19 @@ semver = ">=2.8.1"
 
 [[package]]
 name = "pulumi-tls"
-version = "5.3.1"
+version = "5.4.0"
 description = "A Pulumi package to create TLS resources in Pulumi programs."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pulumi_tls-5.3.1-py3-none-any.whl", hash = "sha256:e9e374b0d553d264b0c8ae00bd4dadd15a74f15fc26979b312f95f8bbbcc1b59"},
-    {file = "pulumi_tls-5.3.1.tar.gz", hash = "sha256:423baaff12eb54450b1ed5909f2267d5b6e1cd734bede21fccdbc7d0a2027400"},
+    {file = "pulumi_tls-5.4.0-py3-none-any.whl", hash = "sha256:245235ebbae8a22b3d883618a02305ac83d3a3db2933a4a113c6deb1f5e2d27a"},
+    {file = "pulumi_tls-5.4.0.tar.gz", hash = "sha256:1defa5717e4ede87e4c4d24c5d2e1cd62064044f92d1a4076349af79e08a8bf6"},
 ]
 
 [package.dependencies]
 parver = ">=0.2.1"
-pulumi = ">=3.165.0,<4.0.0"
+pulumi = ">=3.231.0,<4.0.0"
 semver = ">=2.8.1"
 
 [[package]]
@@ -3151,14 +3151,14 @@ prompt_toolkit = ">=2.0,<4.0"
 
 [[package]]
 name = "requests"
-version = "2.34.0"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.34.0-py3-none-any.whl", hash = "sha256:917520a21b767485ce7c588f4ebb917c436b24a31231b44228715eaeb5a52c60"},
-    {file = "requests-2.34.0.tar.gz", hash = "sha256:7d62fe92f50eb82c529b0916bb445afa1531a566fc8f35ffdc64446e771b856a"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
@@ -3173,30 +3173,30 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.13"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c"},
-    {file = "ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c"},
-    {file = "ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0"},
-    {file = "ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b"},
-    {file = "ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e"},
-    {file = "ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20"},
-    {file = "ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d"},
-    {file = "ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f"},
-    {file = "ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6"},
+    {file = "ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8"},
+    {file = "ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7"},
+    {file = "ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca"},
+    {file = "ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd"},
+    {file = "ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6"},
+    {file = "ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51"},
+    {file = "ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2"},
+    {file = "ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b"},
+    {file = "ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41"},
+    {file = "ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4"},
+    {file = "ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21"},
+    {file = "ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7"},
 ]
 
 [[package]]
@@ -3353,21 +3353,21 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.3.2"
+version = "21.3.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.3.2-py3-none-any.whl", hash = "sha256:c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764"},
-    {file = "virtualenv-21.3.2.tar.gz", hash = "sha256:3ecda97894a6fc1c53106356f488690e5c86278c1f693f3fc0805ac85a513686"},
+    {file = "virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3"},
+    {file = "virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.2.2"
+python-discovery = ">=1.3.1"
 
 [[package]]
 name = "wcwidth"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ packages = [
     { include = "orbitcloud_graviton/azure_tenant", from = "bases" },
     { include = "orbitcloud_graviton/azuresql", from = "bases" },
     { include = "orbitcloud_graviton/cloud_init", from = "components" },
+    { include = "orbitcloud_graviton/datazone", from = "bases" },
     { include = "orbitcloud_graviton/entra", from = "components" },
     { include = "orbitcloud_graviton/entra_external_id", from = "bases" },
     { include = "orbitcloud_graviton/hubspoke", from = "bases" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ packages = [
     { include = "orbitcloud_graviton/az_keyvault", from = "components" },
     { include = "orbitcloud_graviton/az_lib", from = "components" },
     { include = "orbitcloud_graviton/az_monitor", from = "components" },
+    { include = "orbitcloud_graviton/az_mysql", from = "components" },
     { include = "orbitcloud_graviton/az_network", from = "components" },
     { include = "orbitcloud_graviton/az_postgres", from = "components" },
     { include = "orbitcloud_graviton/az_resources", from = "components" },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,12 @@
 # which rules to suppress in specific contexts.
 
 # ============================================================================
+# Source & Test Layout
+# ============================================================================
+sonar.sources=components,bases
+sonar.tests=test
+
+# ============================================================================
 # IP Address Detection (Rule S1313)
 # ============================================================================
 # Exclude test files from IP address detection warnings.
@@ -28,13 +34,13 @@ sonar.issue.ignore.multicriteria=e1,e2
 
 # Suppress rule S1313 (IP address detection) for all test files
 e1.ruleKey=python:S1313
-e1.resourceKey=test/**/*
+e1.resourceKey=**/test/**
 
 # Suppress rule S2068 (hardcoded credentials) for test files
 # Test snapshot data references Pulumi SDK module paths like
 # "pulumi_random.random_password" which triggers false positives.
 e2.ruleKey=python:S2068
-e2.resourceKey=test/**/*
+e2.resourceKey=**/test/**
 
 # ============================================================================
 # Code Duplication Detection
@@ -44,4 +50,4 @@ e2.resourceKey=test/**/*
 # Test data often contains similar patterns and structures, which is expected
 # and intentional for comprehensive test coverage.
 #
-sonar.cpd.exclusions=test/**/*
+sonar.cpd.exclusions=**/test/**

--- a/test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py
+++ b/test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py
@@ -145,6 +145,11 @@ V1_PREFIX_SNAPSHOT: dict[str, dict[str, Any]] = {
     "pulumi_azure_native.network.dnssec_config": {"prefix": "dnssec"},
     "pulumi_azure_native.recoveryservices.vault": {"prefix": "rsv"},
     "pulumi_azure_native.recoveryservices.protection_policy": {"prefix": "rsvpp"},
+    "pulumi_azure_native.dbformysql.server": {"prefix": "mysql"},
+    "pulumi_azure_native.dbformysql.azure_ad_administrator": {"prefix": "mysql-admin"},
+    "pulumi_azure_native.dbformysql.configuration": {"prefix": "mysql-conf"},
+    "pulumi_azure_native.dbformysql.database": {"prefix": "mysql-db"},
+    "pulumi_azure_native.dbformysql.firewall_rule": {"prefix": "mysql-fw"},
 }
 
 
@@ -759,6 +764,11 @@ V1_NAMING_EXPECTED: dict[str, str] = {
     "pulumi_azure_native.network.dnssec_config": "dnssec-workload-test-neu-01",
     "pulumi_azure_native.recoveryservices.vault": "rsv-workload-test-neu-01",
     "pulumi_azure_native.recoveryservices.protection_policy": "rsvpp-workload-test-neu-01",
+    "pulumi_azure_native.dbformysql.server": "mysql-workload-test-neu-01",
+    "pulumi_azure_native.dbformysql.azure_ad_administrator": "mysql-admin-workload-test-neu-01",
+    "pulumi_azure_native.dbformysql.configuration": "mysql-conf-workload-test-neu-01",
+    "pulumi_azure_native.dbformysql.database": "mysql-db-workload-test-neu-01",
+    "pulumi_azure_native.dbformysql.firewall_rule": "mysql-fw-workload-test-neu-01",
 }
 
 
@@ -1173,6 +1183,11 @@ def test_cross_system_v1_only_resources() -> None:
         "pulumi_azure_native.dbforpostgresql.server",
         "pulumi_azure_native.dbforpostgresql.administrator",
         "pulumi_azure_native.dbforpostgresql.configuration",
+        "pulumi_azure_native.dbformysql.server",
+        "pulumi_azure_native.dbformysql.azure_ad_administrator",
+        "pulumi_azure_native.dbformysql.configuration",
+        "pulumi_azure_native.dbformysql.database",
+        "pulumi_azure_native.dbformysql.firewall_rule",
         "pulumi_random.random_password",
         "pulumi_azure_native.compute.virtual_machine",
         "pulumi_azure_native.compute.disk",

--- a/test/components/orbitcloud_graviton/az_mysql/__init__.py
+++ b/test/components/orbitcloud_graviton/az_mysql/__init__.py
@@ -1,0 +1,1 @@
+# MySQL component tests

--- a/test/components/orbitcloud_graviton/az_mysql/test_mysql_config.py
+++ b/test/components/orbitcloud_graviton/az_mysql/test_mysql_config.py
@@ -1,0 +1,372 @@
+import pytest
+from pulumi_azure_native.dbformysql import (
+    CreateMode,
+    EnableStatusEnum,
+    HighAvailabilityMode,
+    ServerSkuTier,
+)
+
+from orbitcloud_graviton.az_mysql.flexibleserver import (
+    MysqlAuthConfig,
+    MysqlBackupConfig,
+    MysqlCreateMode,
+    MysqlDatabaseConfig,
+    MysqlFlexibleServerConfig,
+    MysqlHAConfig,
+    MysqlMaintenanceConfig,
+    MysqlNetworkConfig,
+    MysqlSku,
+    MysqlStorageConfig,
+)
+
+# --- MysqlAuthConfig ---
+
+
+def test_auth_config_defaults() -> None:
+    config = MysqlAuthConfig()
+    assert config.admin_username == "cloudsa"
+    assert config.admin_password is None
+    assert config.entra_auth is True
+
+
+def test_auth_config_custom() -> None:
+    config = MysqlAuthConfig(
+        admin_username="myadmin",
+        admin_password="secret123",  # NOSONAR - test credential
+        entra_auth=False,
+    )
+    assert config.admin_username == "myadmin"
+    assert config.admin_password == "secret123"
+    assert config.entra_auth is False
+
+
+def test_auth_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlAuthConfig.model_validate({"unknown_field": "value"})
+
+
+# --- MysqlNetworkConfig ---
+
+
+def test_network_config_valid() -> None:
+    config = MysqlNetworkConfig(
+        subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+        private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/zone",
+    )
+    assert config.subnet_id is not None
+    assert config.private_dns_zone_id is not None
+
+
+def test_network_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlNetworkConfig.model_validate(
+            {
+                "subnet_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+                "private_dns_zone_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+                "extra": "nope",
+            }
+        )
+
+
+# --- MysqlStorageConfig ---
+
+
+def test_storage_config_defaults() -> None:
+    config = MysqlStorageConfig()
+    assert config.storage_size_gb == 32
+    assert config.auto_grow == EnableStatusEnum.DISABLED
+    assert config.auto_io_scaling == EnableStatusEnum.ENABLED
+    assert config.iops is None
+
+
+def test_storage_config_custom() -> None:
+    config = MysqlStorageConfig(
+        storage_size_gb=128,
+        auto_grow=EnableStatusEnum.ENABLED,
+        auto_io_scaling=EnableStatusEnum.DISABLED,
+        iops=5000,
+    )
+    assert config.storage_size_gb == 128
+    assert config.iops == 5000
+
+
+def test_storage_config_min_size() -> None:
+    with pytest.raises(ValueError):
+        MysqlStorageConfig(storage_size_gb=15)
+
+
+def test_storage_config_max_size() -> None:
+    with pytest.raises(ValueError):
+        MysqlStorageConfig(storage_size_gb=100000)
+
+
+def test_storage_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlStorageConfig.model_validate({"extra": "nope"})
+
+
+# --- MysqlBackupConfig ---
+
+
+def test_backup_config_defaults() -> None:
+    config = MysqlBackupConfig()
+    assert config.geo_redundant == EnableStatusEnum.DISABLED
+    assert config.retention_days == 7
+
+
+def test_backup_config_custom() -> None:
+    config = MysqlBackupConfig(
+        geo_redundant=EnableStatusEnum.ENABLED,
+        retention_days=35,
+    )
+    assert config.geo_redundant == EnableStatusEnum.ENABLED
+    assert config.retention_days == 35
+
+
+def test_backup_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlBackupConfig.model_validate({"extra": "nope"})
+
+
+# --- MysqlSku ---
+
+
+def test_sku_defaults() -> None:
+    config = MysqlSku()
+    assert config.name == "Standard_B1ms"
+    assert config.tier == ServerSkuTier.BURSTABLE
+
+
+def test_sku_custom() -> None:
+    config = MysqlSku(name="Standard_D2ds_v4", tier=ServerSkuTier.GENERAL_PURPOSE)
+    assert config.name == "Standard_D2ds_v4"
+    assert config.tier == ServerSkuTier.GENERAL_PURPOSE
+
+
+def test_sku_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlSku.model_validate({"extra": "nope"})
+
+
+# --- MysqlHAConfig ---
+
+
+def test_ha_config_defaults() -> None:
+    config = MysqlHAConfig()
+    assert config.mode == HighAvailabilityMode.DISABLED
+    assert config.standby_availability_zone is None
+
+
+def test_ha_config_zone_redundant() -> None:
+    config = MysqlHAConfig(
+        mode=HighAvailabilityMode.ZONE_REDUNDANT,
+        standby_availability_zone="2",
+    )
+    assert config.mode == HighAvailabilityMode.ZONE_REDUNDANT
+    assert config.standby_availability_zone == "2"
+
+
+def test_ha_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlHAConfig.model_validate({"extra": "nope"})
+
+
+# --- MysqlMaintenanceConfig ---
+
+
+def test_maintenance_config_defaults() -> None:
+    config = MysqlMaintenanceConfig()
+    assert config.day_of_week == 0
+    assert config.start_hour == 0
+    assert config.start_minute == 0
+
+
+def test_maintenance_config_custom() -> None:
+    config = MysqlMaintenanceConfig(day_of_week=3, start_hour=2, start_minute=30)
+    assert config.day_of_week == 3
+
+
+def test_maintenance_config_day_range() -> None:
+    with pytest.raises(ValueError):
+        MysqlMaintenanceConfig(day_of_week=7)
+
+
+def test_maintenance_config_hour_range() -> None:
+    with pytest.raises(ValueError):
+        MysqlMaintenanceConfig(start_hour=24)
+
+
+def test_maintenance_config_minute_range() -> None:
+    with pytest.raises(ValueError):
+        MysqlMaintenanceConfig(start_minute=60)
+
+
+def test_maintenance_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlMaintenanceConfig.model_validate({"extra": "nope"})
+
+
+# --- MysqlCreateMode ---
+
+
+def test_create_mode_defaults() -> None:
+    config = MysqlCreateMode()
+    assert config.mode is None
+    assert config.source_server_id is None
+    assert config.restore_point_in_time is None
+
+
+def test_create_mode_pitr_requires_source() -> None:
+    with pytest.raises(ValueError, match="source_server_id is required"):
+        MysqlCreateMode(mode=CreateMode.POINT_IN_TIME_RESTORE)
+
+
+def test_create_mode_geo_restore_requires_source() -> None:
+    with pytest.raises(ValueError, match="source_server_id is required"):
+        MysqlCreateMode(mode=CreateMode.GEO_RESTORE)
+
+
+def test_create_mode_replica_requires_source() -> None:
+    with pytest.raises(ValueError, match="source_server_id is required"):
+        MysqlCreateMode(mode=CreateMode.REPLICA)
+
+
+def test_create_mode_pitr_requires_restore_time() -> None:
+    with pytest.raises(ValueError, match="restore_point_in_time is required"):
+        MysqlCreateMode(
+            mode=CreateMode.POINT_IN_TIME_RESTORE,
+            source_server_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.DBforMySQL/flexibleServers/src",
+        )
+
+
+def test_create_mode_pitr_valid() -> None:
+    config = MysqlCreateMode(
+        mode=CreateMode.POINT_IN_TIME_RESTORE,
+        source_server_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.DBforMySQL/flexibleServers/src",
+        restore_point_in_time="2024-01-01T00:00:00Z",
+    )
+    assert config.mode == CreateMode.POINT_IN_TIME_RESTORE
+    assert config.restore_point_in_time == "2024-01-01T00:00:00Z"
+
+
+def test_create_mode_geo_restore_valid() -> None:
+    config = MysqlCreateMode(
+        mode=CreateMode.GEO_RESTORE,
+        source_server_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.DBforMySQL/flexibleServers/src",
+    )
+    assert config.mode == CreateMode.GEO_RESTORE
+
+
+def test_create_mode_replica_valid() -> None:
+    config = MysqlCreateMode(
+        mode=CreateMode.REPLICA,
+        source_server_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.DBforMySQL/flexibleServers/src",
+    )
+    assert config.mode == CreateMode.REPLICA
+
+
+def test_create_mode_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlCreateMode.model_validate({"extra": "nope"})
+
+
+# --- MysqlDatabaseConfig ---
+
+
+def test_database_config_defaults() -> None:
+    config = MysqlDatabaseConfig(name="mydb")
+    assert config.name == "mydb"
+    assert config.charset == "utf8mb4"
+    assert config.collation == "utf8mb4_unicode_ci"
+
+
+def test_database_config_custom() -> None:
+    config = MysqlDatabaseConfig(name="mydb", charset="latin1", collation="latin1_swedish_ci")
+    assert config.charset == "latin1"
+    assert config.collation == "latin1_swedish_ci"
+
+
+def test_database_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlDatabaseConfig.model_validate({"name": "db", "extra": "nope"})
+
+
+# --- MysqlFlexibleServerConfig ---
+
+
+def test_server_config_defaults() -> None:
+    config = MysqlFlexibleServerConfig()
+    assert config.server_name is None
+    assert config.server_version == "8.4"
+    assert config.network is None
+    assert config.allowed_public_networks is None
+    assert config.allow_azure_services is False
+    assert config.databases is None
+    assert config.server_params is None
+    assert config.log_workspace_id is None
+
+
+def test_server_config_vnet_and_firewall_mutually_exclusive() -> None:
+    from orbitcloud_graviton.az_network.types import PublicIpv4FirewallRule
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        MysqlFlexibleServerConfig(
+            network=MysqlNetworkConfig(
+                subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+                private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+            ),
+            allowed_public_networks=[
+                PublicIpv4FirewallRule(name="office", cidr="8.8.8.0/24"),  # type: ignore[arg-type]  # NOSONAR
+            ],
+        )
+
+
+def test_server_config_vnet_with_empty_firewall_list_allowed() -> None:
+    """Empty list for allowed_public_networks should not trigger mutual exclusion."""
+    config = MysqlFlexibleServerConfig(
+        network=MysqlNetworkConfig(
+            subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+            private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+        ),
+        allowed_public_networks=[],
+    )
+    assert config.network is not None
+    assert config.allowed_public_networks == []
+
+
+def test_server_config_vnet_and_azure_services_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        MysqlFlexibleServerConfig(
+            network=MysqlNetworkConfig(
+                subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+                private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+            ),
+            allow_azure_services=True,
+        )
+
+
+def test_server_config_with_network() -> None:
+    config = MysqlFlexibleServerConfig(
+        network=MysqlNetworkConfig(
+            subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+            private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+        ),
+    )
+    assert config.network is not None
+
+
+def test_server_config_with_firewall_rules() -> None:
+    from orbitcloud_graviton.az_network.types import PublicIpv4FirewallRule
+
+    config = MysqlFlexibleServerConfig(
+        allowed_public_networks=[
+            PublicIpv4FirewallRule(name="office", cidr="8.8.8.0/24"),  # type: ignore[arg-type]  # NOSONAR
+        ],
+    )
+    assert config.allowed_public_networks is not None
+    assert len(config.allowed_public_networks) == 1
+
+
+def test_server_config_forbids_extra() -> None:
+    with pytest.raises(ValueError):
+        MysqlFlexibleServerConfig.model_validate({"extra": "nope"})

--- a/test/components/orbitcloud_graviton/az_mysql/test_mysql_resource.py
+++ b/test/components/orbitcloud_graviton/az_mysql/test_mysql_resource.py
@@ -1,0 +1,307 @@
+"""Pulumi resource-creation tests for MysqlFlexibleServer.
+
+These tests use Pulumi mocks to verify that the correct Azure resources
+are created with the expected properties.
+"""
+
+import logging
+from uuid import UUID
+
+import pulumi
+from pulumi_azure_native import dbformysql as mysql
+
+from orbitcloud_graviton.az_network.types import PublicIpv4FirewallRule
+from orbitcloud_graviton.pulumi_mocks import set_mocks
+
+set_mocks()
+
+from orbitcloud_graviton.az_mysql import (  # noqa: E402
+    MysqlAuthConfig,
+    MysqlDatabaseConfig,
+    MysqlFlexibleServer,
+    MysqlFlexibleServerConfig,
+)
+from orbitcloud_graviton.pulumi_lib import AzureStack, EntraStack  # noqa: E402
+
+# --- Fixtures ---
+
+
+def _make_stack(**overrides) -> AzureStack:
+    defaults = {
+        "subscription_id": UUID("00000000-0000-0000-0000-000000000000"),
+        "tenant_id": UUID("00000000-0000-0000-0000-000000000000"),
+        "location": "northeurope",
+        "workload_name": "testworkload",
+        "env": "test",
+        "skip_exports": True,
+    }
+    defaults.update(overrides)
+    return AzureStack(**defaults)
+
+
+def _make_entra() -> EntraStack:
+    return EntraStack.model_validate({"azuread:tenantId": "00000000-0000-0000-0000-000000000000"})
+
+
+# --- Tests ---
+
+
+@pulumi.runtime.test
+def test_server_created_with_defaults() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert isinstance(component.server, mysql.Server)
+
+
+@pulumi.runtime.test
+def test_auto_generated_password() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    # admin_password should be a Pulumi Output (from RandomPassword)
+    assert isinstance(component.admin_password, pulumi.Output)
+
+
+@pulumi.runtime.test
+def test_explicit_password_used() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        authentication=MysqlAuthConfig(
+            admin_password="my-explicit-pw"
+        ),  # NOSONAR - test credential
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.admin_password == "my-explicit-pw"
+
+
+@pulumi.runtime.test
+def test_public_network_access_enabled_without_vnet() -> None:
+    """Without VNet config, public network access should be ENABLED."""
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    def check(args):
+        public_access = args
+        assert public_access == mysql.EnableStatusEnum.ENABLED
+
+    component.server.network.public_network_access.apply(check)
+
+
+@pulumi.runtime.test
+def test_public_network_access_disabled_with_vnet() -> None:
+    """With VNet config, public network access should be DISABLED."""
+    from orbitcloud_graviton.az_mysql import MysqlNetworkConfig
+
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        network=MysqlNetworkConfig(
+            subnet_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/default",
+            private_dns_zone_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/privateDnsZones/mysql.database.azure.com",
+        ),
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    def check(args):
+        public_access = args
+        assert public_access == mysql.EnableStatusEnum.DISABLED
+
+    component.server.network.public_network_access.apply(check)
+
+
+@pulumi.runtime.test
+def test_databases_created() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        databases=[
+            MysqlDatabaseConfig(name="db1"),
+            MysqlDatabaseConfig(name="db2", charset="latin1", collation="latin1_swedish_ci"),
+        ],
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert len(component.databases) == 2
+    assert all(isinstance(db, mysql.Database) for db in component.databases)
+
+
+@pulumi.runtime.test
+def test_no_databases_when_none() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.databases == []
+
+
+@pulumi.runtime.test
+def test_firewall_rules_created() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        allowed_public_networks=[
+            PublicIpv4FirewallRule(name="office", cidr="8.8.8.0/24"),  # type: ignore[arg-type]  # NOSONAR
+            PublicIpv4FirewallRule(name="vpn", cidr="1.2.3.0/24"),  # type: ignore[arg-type]  # NOSONAR
+        ],
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert len(component.firewall_rules) == 2
+    assert all(isinstance(r, mysql.FirewallRule) for r in component.firewall_rules)
+
+
+@pulumi.runtime.test
+def test_no_firewall_rules_when_none() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.firewall_rules == []
+
+
+@pulumi.runtime.test
+def test_azure_services_rule_created() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(allow_azure_services=True)
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert isinstance(component.azure_services_rule, mysql.FirewallRule)
+
+
+@pulumi.runtime.test
+def test_no_azure_services_rule_by_default() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.azure_services_rule is None
+
+
+@pulumi.runtime.test
+def test_server_params_created() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        server_params={"max_connections": "200", "slow_query_log": "ON"},
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.server_params is not None
+    assert len(component.server_params) == 2
+    assert all(isinstance(p, mysql.Configuration) for p in component.server_params)
+
+
+@pulumi.runtime.test
+def test_no_server_params_when_none() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.server_params is None
+
+
+@pulumi.runtime.test
+def test_entra_admin_not_created_without_azure_environment() -> None:
+    """When azure_environment is not set, no Entra admin should be created."""
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.admins is None
+
+
+@pulumi.runtime.test
+def test_entra_admin_not_created_when_disabled() -> None:
+    """When entra_auth=False, no Entra admin should be created."""
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        authentication=MysqlAuthConfig(entra_auth=False),
+    )
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert component.admins is None
+
+
+@pulumi.runtime.test
+def test_entra_admin_created_with_azure_environment() -> None:
+    """When azure_environment is set and entra_auth=True, Entra admin should be created."""
+    from orbitcloud_graviton.pulumi_lib.azure_base import (
+        AzureEnvironmentPulumiConfig,
+        EntraEscApp,
+    )
+
+    stack = _make_stack(
+        azure_environment=AzureEnvironmentPulumiConfig(
+            pulumi_esc_app=EntraEscApp(
+                name="test-esc-app",
+                app_client_id=UUID("11111111-1111-1111-1111-111111111111"),
+                app_object_id=UUID("22222222-2222-2222-2222-222222222222"),
+                service_principal_id="sp-id",
+                service_principal_object_id=UUID("33333333-3333-3333-3333-333333333333"),
+            ),
+            resource_group_name="rg-test",
+        ),
+    )
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert isinstance(component.admins, mysql.AzureADAdministrator)
+
+
+@pulumi.runtime.test
+def test_warning_logged_when_entra_auth_but_no_azure_environment(caplog) -> None:
+    """A warning should be logged when entra_auth=True but azure_environment is missing."""
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(authentication=MysqlAuthConfig(entra_auth=True))
+
+    with caplog.at_level(logging.WARNING, logger="orbitcloud_graviton.az_mysql.flexibleserver"):
+        MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert any(
+        "Entra authentication is enabled but azure_environment is not set" in r.message
+        for r in caplog.records
+    )
+
+
+@pulumi.runtime.test
+def test_no_warning_when_entra_auth_disabled(caplog) -> None:
+    """No warning should be logged when entra_auth=False."""
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(
+        authentication=MysqlAuthConfig(entra_auth=False),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="orbitcloud_graviton.az_mysql.flexibleserver"):
+        MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    assert not any("Entra authentication is enabled" in r.message for r in caplog.records)
+
+
+@pulumi.runtime.test
+def test_server_sku_properties() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig()
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    def check(args):
+        sku_name, sku_tier = args
+        assert sku_name == "Standard_B1ms"
+        assert sku_tier == mysql.ServerSkuTier.BURSTABLE
+
+    pulumi.Output.all(
+        component.server.sku.name,
+        component.server.sku.tier,
+    ).apply(check)
+
+
+@pulumi.runtime.test
+def test_server_version() -> None:
+    stack = _make_stack()
+    config = MysqlFlexibleServerConfig(server_version="8.0.21")
+    component = MysqlFlexibleServer(stack=stack, entra_config=_make_entra(), config=config)
+
+    def check(version):
+        assert version == "8.0.21"
+
+    component.server.version.apply(check)


### PR DESCRIPTION
## Summary

Adds a new `datazone` base that bundles data-tier resources (Postgres / MySQL / Azure SQL / Storage) into a single Pulumi project — analogous to how `app_zone` bundles compute. All four resource groups are optional; consumers deploy only what their stack config provides.

## What's new

**`bases/orbitcloud_graviton/datazone/`** — new polylith base
- `DataZoneBaseConfig` (Pulumi config):
  - `postgres: PostgresFlexibleServerConfig | None`
  - `mysql: MysqlFlexibleServerConfig | None`
  - `sql_server: SqlServerConfig | None` + `sql_databases: list[SqlDatabaseConfig] | None`
  - `storage_accounts: list[StorageAccountConfig] | None`
  - `log_workspace_id: AzureIdRef | None` (propagated to each component config)
- `deploy()` orchestrates: skips resource groups whose config block is unset; threads `log_workspace_id` through to diagnostics; reuses the existing `entra_admin` / `elastic_pool` flow from `azuresql` base.

**`pyproject.toml`** — adds the new base to `[tool.poetry] packages`.

## Also in this PR

- `build(deps)`: refresh of patch-level deps that came up during validation (pulumi 3.237→3.239, pulumi-cloudinit, pulumi-random, pulumi-tls, ruff, commitizen, etc.)
- pre-commit: `commitizen-tools/commitizen` v4.16.0 → v4.16.2

## Depends on

PR #246 (`feat(az_mysql): add MySQL Flexible Server component`) — this branch was merged onto #246's `feature/mysql-flexible-server`. Once #246 lands, the diff here narrows to just the datazone + deps commits.

## Test plan
- [x] `make lint` clean
- [x] `make test` — 685 passed, 4 skipped (existing component tests cover the wiring)
- [ ] CI green
- [ ] Downstream consumer project validates postgres provisioning end-to-end against the new base (already verified locally)