### PR TITLE
fix(az_lib): use configurationStores for App Configuration private link groupId

### DIFF
--- a/components/orbitcloud_graviton/az_lib/metadata/services/appconfiguration.yaml
+++ b/components/orbitcloud_graviton/az_lib/metadata/services/appconfiguration.yaml
@@ -4,7 +4,7 @@ resources:
     naming:
       prefix: appcs
     namespace: Microsoft.AppConfiguration/configurationStores
-    sub_resource_name: configurationStore
+    sub_resource_name: configurationStores
     public_dns_zone: azconfig.io
     private_dns_zone: privatelink.azconfig.io
   KeyValue:

--- a/test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py
+++ b/test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py
@@ -220,7 +220,7 @@ V2_METADATA_SNAPSHOT: dict[str, Any] = {
             "ConfigurationStore": {
                 "naming": {"prefix": "appcs"},
                 "namespace": "Microsoft.AppConfiguration/configurationStores",
-                "sub_resource_name": "configurationStore",
+                "sub_resource_name": "configurationStores",
                 "public_dns_zone": "azconfig.io",
                 "private_dns_zone": "privatelink.azconfig.io",
             },


### PR DESCRIPTION
Private endpoints for App Configuration were failing because metadata used `configurationStore` as the private link group ID. Azure expects `configurationStores` (plural)—see the [private link resources API](https://learn.microsoft.com/en-us/rest/api/appconfiguration/private-link-resources/list-by-configuration-store) for a configuration store.

This changes `sub_resource_name` in `appconfiguration.yaml` and updates the metadata snapshot test.

Typical ARM error with the wrong value: *The specified resource type 'configurationStore' is not supported.*

**Test plan:** `pytest test/components/orbitcloud_graviton/az_lib/test_metadata_snapshot.py` passes locally. Rest is the usual `make fmt && make lint && make test && make pyright`.
