### PR TITLE
ci: post pytest coverage comment via workflow_run to support fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
   test:
     permissions:
       contents: read
-      pull-requests: write
     name: Test & lint
     runs-on: ubuntu-latest
     steps:
@@ -60,12 +59,20 @@ jobs:
       - run: poetry run make lint
       - run: poetry run make test
 
-      - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@v1.7.2
+      - name: Save PR number
         if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
+      - name: Upload coverage artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
+          name: coverage-report
+          path: |
+            pytest-coverage.txt
+            pytest.xml
+            pr_number.txt
+          retention-days: 1
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'bump:') && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,9 @@ jobs:
 
       - name: Save PR number
         if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.number }}" > pr_number.txt
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo "$PR_NUMBER" > pr_number.txt
 
       - name: Upload coverage artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,45 @@
+name: Coverage comment
+# Runs in the base branch context with write permissions and posts the
+# coverage comment for PRs (including forks). It does NOT check out
+# the PR's code — it only downloads the artifact produced by the Build
+# workflow, so untrusted fork code never executes with the write token.
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          # Sanitize: only accept a positive integer.
+          number=$(tr -cd '0-9' < pr_number.txt)
+          if [ -z "$number" ]; then
+            echo "No valid PR number in artifact" >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Post pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@v1.7.2
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
+          issue-number: ${{ steps.pr.outputs.number }}
+          report-only-changed-files: true
+          xml-skip-covered: true


### PR DESCRIPTION
## Summary

- Move the pytest coverage PR comment off the build job and into a separate `workflow_run`-triggered workflow so it can post on fork PRs without granting write permissions to a job that runs untrusted code.
- Build job now drops `pull-requests: write` and uploads `pytest-coverage.txt`, `pytest.xml`, and the PR number as an artifact.
- New `coverage-comment.yml` triggers on `workflow_run` (Build completed), runs in base-branch context, downloads the artifact, sanitizes the PR number to a positive integer, and posts via `MishaKav/pytest-coverage-comment`. Fork code never executes with the write-scoped token.
- Adds `report-only-changed-files: true` and `xml-skip-covered: true` to keep the comment under the 65,536 character ceiling.

## Background

Fork PRs (e.g. #282) were failing the comment step with `Resource not accessible by integration` because GitHub restricts `GITHUB_TOKEN` to read-only on `pull_request` events from forks. The action's suggested fix (`pull_request_target`) is footgun-prone; `workflow_run` is GitHub Security Lab's recommended pattern for this case.

## Caveats

- `workflow_run` only fires from workflows present on the default branch, so the first PR to benefit from the comment is one opened **after** this lands on `main`.
- End-to-end validation from a fork PR is only possible once this is merged.

## Test plan

- [ ] Verify the artifact upload step runs on this PR.
- [ ] After merge, verify a fork PR (e.g. a follow-up to #282) gets a coverage comment posted by the `Coverage comment` workflow.
- [ ] Confirm the comment respects the size limits (no `Your comment is too long` warning).